### PR TITLE
Added mechanism modules to the app

### DIFF
--- a/src/editor/editor.ts
+++ b/src/editor/editor.ts
@@ -129,8 +129,8 @@ export class Editor {
               this.workspaceContent = moduleContent
             }
 
-            // If both the workspace and the module have been loaded, load the
-            // blocks into the blockly workspace.
+            // If both the workspace content and the module content have been
+            // loaded, load the blocks into the blockly workspace.
             if (this.workspaceContent) {
               this.loadBlocksIntoBlocklyWorkspace();
             }
@@ -164,6 +164,7 @@ export class Editor {
     if (this.bindedOnChange) {
       this.blocklyWorkspace.removeChangeListener(this.bindedOnChange);
     }
+    this.blocklyWorkspace.hideChaff();
     this.blocklyWorkspace.clear();
     this.blocklyWorkspace.scroll(0, 0);
     this.setToolbox(EMPTY_TOOLBOX);
@@ -217,7 +218,7 @@ export class Editor {
     const pythonCode = extendedPythonGenerator.workspaceToCode(this.blocklyWorkspace);
     const exportedBlocks = JSON.stringify(extendedPythonGenerator.getExportedBlocks(this.blocklyWorkspace));
     const blocksContent = JSON.stringify(Blockly.serialization.workspaces.save(this.blocklyWorkspace));
-    return commonStorage.makeModuleContent(pythonCode, exportedBlocks, blocksContent);
+    return commonStorage.makeModuleContent(this.currentModule, pythonCode, exportedBlocks, blocksContent);
   }
 
   public saveModule(callback: storage.BooleanCallback): void {

--- a/src/editor/extended_python_generator.ts
+++ b/src/editor/extended_python_generator.ts
@@ -165,8 +165,8 @@ export class ExtendedPythonGenerator extends PythonGenerator {
       return code;
     }
 
-    let className = this.currentModule.moduleName;
-    let classType = this.currentModule.moduleType;
+    const className = this.currentModule.moduleName;
+    const classType = this.currentModule.moduleType;
 
     this.addImport(classType);
 


### PR DESCRIPTION
Added mechanisms to the app (new mechanism, show mechanism in the tree, rename/copy mechanism, etc).

Set the title of the workspace name modal bases on what is being done (new workspace, rename workspace, copy workspace). Set the title of the module name modal bases on what is being done (new workspace, rename workspace, copy workspace).

Fixed a problem where the module type wasn't being passed to the python generator when it generates the python code for the UI.

When a new module is selected and we are updating the blocks editor area, close the toolbox flyout if it is open.

When saving a module to storage, include the module type. Improved the code that writes and reads modules (Workspaces, Mechanisms, and OpModes) to/from storage.