### PR TITLE
Make mrc_call_python_function work for calling methods in the same class.

### DIFF
--- a/src/blocks/mrc_call_python_function.ts
+++ b/src/blocks/mrc_call_python_function.ts
@@ -37,6 +37,7 @@ const FUNCTION_KIND_MODULE = 'module';
 const FUNCTION_KIND_STATIC = 'static';
 const FUNCTION_KIND_CONSTRUCTOR = 'constructor';
 const FUNCTION_KIND_INSTANCE = 'instance';
+const FUNCTION_KIND_INSTANCE_WITHIN = 'instance_within';
 
 const RETURN_TYPE_NONE = 'None';
 
@@ -125,6 +126,11 @@ const CALL_PYTHON_FUNCTION = {
           const className = this.getFieldValue(pythonUtils.FIELD_MODULE_OR_CLASS_NAME);
           const functionName = this.getFieldValue(pythonUtils.FIELD_FUNCTION_NAME);
           tooltip = 'Calls the function ' + className + '.' + functionName + '.';
+          break;
+        }
+        case FUNCTION_KIND_INSTANCE_WITHIN: {
+          const functionName = this.getFieldValue(pythonUtils.FIELD_FUNCTION_NAME);
+          tooltip = 'Calls the method ' + functionName + '.';
           break;
         }
         default:
@@ -238,6 +244,11 @@ const CALL_PYTHON_FUNCTION = {
             .appendField('.')
             .appendField(createFieldNonEditableText(''), pythonUtils.FIELD_FUNCTION_NAME);
         break;
+      case FUNCTION_KIND_INSTANCE_WITHIN:
+        this.appendDummyInput()
+            .appendField('call')
+            .appendField(createFieldNonEditableText(''), pythonUtils.FIELD_FUNCTION_NAME);
+        break;
       default:
         throw new Error('mrcVarKind must be "module", "static", "constructor", or "instance".')
     }
@@ -299,6 +310,14 @@ export const pythonFromBlock = function(
           : block.getFieldValue(pythonUtils.FIELD_FUNCTION_NAME);
       code = selfValue + '.' + functionName;
       argStartIndex = 1; // Skip the self argument.
+      break;
+    }
+    case FUNCTION_KIND_INSTANCE_WITHIN: {
+      const callPythonFunctionBlock = block as CallPythonFunctionBlock;
+      const functionName = (callPythonFunctionBlock.mrcActualFunctionName)
+          ? callPythonFunctionBlock.mrcActualFunctionName
+          : block.getFieldValue(pythonUtils.FIELD_FUNCTION_NAME);
+      code = 'self.' + functionName;
       break;
     }
   }

--- a/src/blocks/mrc_call_python_function.ts
+++ b/src/blocks/mrc_call_python_function.ts
@@ -48,7 +48,7 @@ export type FunctionArg = {
 
 type CallPythonFunctionBlock = Blockly.Block & CallPythonFunctionMixin;
 interface CallPythonFunctionMixin extends CallPythonFunctionMixinType {
-  mrcFunctionKind: string, // module, static, constructor, or instance
+  mrcFunctionKind: string, // module, static, constructor, instance, or instance_within.
   mrcReturnType: string,
   mrcArgs: FunctionArg[],
   mrcTooltip: string,
@@ -61,7 +61,7 @@ type CallPythonFunctionMixinType = typeof CALL_PYTHON_FUNCTION;
 /** Extra state for serialising call_python_* blocks. */
 type CallPythonFunctionExtraState = {
   /**
-   * The kind of function: module, static, constructor, or instance.
+   * The kind of function: module, static, constructor, instance, or instance_within.
    */
   functionKind: string,
   /**
@@ -134,7 +134,7 @@ const CALL_PYTHON_FUNCTION = {
           break;
         }
         default:
-          throw new Error('mrcVarKind must be "module", "static", "constructor", or "instance".')
+          throw new Error('mrcVarKind must be "module", "static", "constructor", "instance", or "instance_within".')
       }
       const funcTooltip = this.mrcTooltip;
       if (funcTooltip) {
@@ -250,7 +250,7 @@ const CALL_PYTHON_FUNCTION = {
             .appendField(createFieldNonEditableText(''), pythonUtils.FIELD_FUNCTION_NAME);
         break;
       default:
-        throw new Error('mrcVarKind must be "module", "static", "constructor", or "instance".')
+        throw new Error('mrcVarKind must be "module", "static", "constructor", "instance", or "instance_within".')
     }
     // Add input sockets for the arguments.
     for (let i = 0; i < this.mrcArgs.length; i++) {
@@ -320,6 +320,8 @@ export const pythonFromBlock = function(
       code = 'self.' + functionName;
       break;
     }
+    default:
+      throw new Error('mrcVarKind must be "module", "static", "constructor", "instance", or "instance_within".')
   }
   code += '(' + generateCodeForArguments(callPythonFunctionBlock, generator, argStartIndex) + ')';
   if (block.outputConnection) {


### PR DESCRIPTION
Make mrc_call_python_function work for calling methods in the same class.

Fixes #64 
