### PR TITLE
Modified ExtendedPythonGenerator so it can safely be a singleton

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -253,7 +253,7 @@ const App: React.FC = () => {
   const [deleteTooltip, setDeleteTooltip] = useState('Delete');
   const blocklyComponent = useRef<BlocklyComponentType | null>(null);
   const [triggerPythonRegeneration, setTriggerPythonRegeneration] = useState(0);
-  const generatorContext = useRef(createGeneratorContext());
+  const generatorContext = useRef<GeneratorContext | null>(null);
   const blocksEditor = useRef<editor.Editor | null>(null);
   const [generatedCode, setGeneratedCode] = useState('');
   const [newProjectNameModalPurpose, setNewProjectNameModalPurpose] = useState('');
@@ -534,7 +534,8 @@ const App: React.FC = () => {
       blocklyWorkspace.addChangeListener(mutatorOpenListener);
       blocklyWorkspace.addChangeListener(handleBlocksChanged);
     }
-    blocksEditor.current = new editor.Editor(blocklyWorkspace, storage);
+    generatorContext.current = createGeneratorContext();
+    blocksEditor.current = new editor.Editor(blocklyWorkspace, generatorContext.current, storage);
   }, [blocklyComponent, storage]);
 
   const handleBlocksChanged = (event: Blockly.Events.Abstract) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,6 +49,7 @@ import { initialize as initializeGeneratedBlocks } from './blocks/utils/generate
 
 import * as editor from './editor/editor';
 import { extendedPythonGenerator } from './editor/extended_python_generator';
+import { createGeneratorContext, GeneratorContext } from './editor/generator_context';
 
 import * as toolboxItems from './toolbox/items';
 import * as toolbox from './toolbox/toolbox';
@@ -252,6 +253,7 @@ const App: React.FC = () => {
   const [deleteTooltip, setDeleteTooltip] = useState('Delete');
   const blocklyComponent = useRef<BlocklyComponentType | null>(null);
   const [triggerPythonRegeneration, setTriggerPythonRegeneration] = useState(0);
+  const generatorContext = useRef(createGeneratorContext());
   const blocksEditor = useRef<editor.Editor | null>(null);
   const [generatedCode, setGeneratedCode] = useState('');
   const [newProjectNameModalPurpose, setNewProjectNameModalPurpose] = useState('');
@@ -461,6 +463,9 @@ const App: React.FC = () => {
         ? commonStorage.findModule(modules, currentModulePath)
         : null;
     setCurrentModule(module);
+    if (generatorContext.current) {
+      generatorContext.current.setModule(module);
+    }
 
     if (module != null) {
       if (module.moduleType == commonStorage.MODULE_TYPE_PROJECT) {
@@ -498,10 +503,12 @@ const App: React.FC = () => {
     if (ignoreEffect()) {
       return;
     }
-    if (blocklyComponent.current) {
+    if (currentModule && blocklyComponent.current && generatorContext.current) {
       const blocklyWorkspace = blocklyComponent.current.getBlocklyWorkspace();
-      extendedPythonGenerator.setCurrentModule(currentModule);
-      setGeneratedCode(extendedPythonGenerator.workspaceToCode(blocklyWorkspace));
+      setGeneratedCode(extendedPythonGenerator.workspaceToCode(
+          blocklyWorkspace, generatorContext.current));
+    } else {
+      setGeneratedCode('');
     }
   }, [currentModule, triggerPythonRegeneration, blocklyComponent]);
 

--- a/src/blocks/mrc_class_method_def.ts
+++ b/src/blocks/mrc_class_method_def.ts
@@ -389,7 +389,7 @@ export const pythonFromBlock = function (
     }
 
     let params = block.mrcParameters;
-    let paramString = "self"
+    let paramString = "self";
     if (params.length != 0) {
         block.mrcParameters.forEach((param) => {
             paramString += ', ' + param.name;
@@ -409,7 +409,7 @@ export const pythonFromBlock = function (
         xfix2 +
         returnValue;
     code = generator.scrub_(block, code);
-    generator.addMethod(funcName, code);
+    generator.addClassMethodDefinition(block.getFieldValue('NAME'), funcName, code);
 
-    return code;
+    return '';
 }

--- a/src/editor/editor.ts
+++ b/src/editor/editor.ts
@@ -22,7 +22,7 @@
 import * as Blockly from 'blockly/core';
 
 import { extendedPythonGenerator } from './extended_python_generator';
-import { createGeneratorContext, GeneratorContext } from './generator_context';
+import { GeneratorContext } from './generator_context';
 import * as commonStorage from '../storage/common_storage';
 import { getToolboxJSON } from '../toolbox/toolbox';
 
@@ -33,8 +33,8 @@ const EMPTY_TOOLBOX: Blockly.utils.toolbox.ToolboxDefinition = {
 };
 
 export class Editor {
-  private generatorContext = createGeneratorContext();
   private blocklyWorkspace: Blockly.WorkspaceSvg;
+  private generatorContext: GeneratorContext;
   private storage: commonStorage.Storage;
   private currentModule: commonStorage.Module | null = null;
   private modulePath: string = '';
@@ -44,8 +44,9 @@ export class Editor {
   private bindedOnChange: any = null;
   private toolbox: Blockly.utils.toolbox.ToolboxDefinition = EMPTY_TOOLBOX;
 
-  constructor(blocklyWorkspace: Blockly.WorkspaceSvg, storage: commonStorage.Storage) {
+  constructor(blocklyWorkspace: Blockly.WorkspaceSvg, generatorContext: GeneratorContext, storage: commonStorage.Storage) {
     this.blocklyWorkspace = blocklyWorkspace;
+    this.generatorContext = generatorContext;
     this.storage = storage;
   }
 

--- a/src/editor/editor.ts
+++ b/src/editor/editor.ts
@@ -22,6 +22,7 @@
 import * as Blockly from 'blockly/core';
 
 import { extendedPythonGenerator } from './extended_python_generator';
+import { createGeneratorContext, GeneratorContext } from './generator_context';
 import * as commonStorage from '../storage/common_storage';
 import { getToolboxJSON } from '../toolbox/toolbox';
 
@@ -32,6 +33,7 @@ const EMPTY_TOOLBOX: Blockly.utils.toolbox.ToolboxDefinition = {
 };
 
 export class Editor {
+  private generatorContext = createGeneratorContext();
   private blocklyWorkspace: Blockly.WorkspaceSvg;
   private storage: commonStorage.Storage;
   private currentModule: commonStorage.Module | null = null;
@@ -104,6 +106,7 @@ export class Editor {
   }
 
   public async loadModuleBlocks(currentModule: commonStorage.Module | null) {
+    this.generatorContext.setModule(currentModule);
     this.currentModule = currentModule;
     if (currentModule) {
       this.modulePath = currentModule.modulePath;
@@ -203,9 +206,8 @@ export class Editor {
   }
 
   private getModuleContent(): string {
-    extendedPythonGenerator.setCurrentModule(this.currentModule);
-    const pythonCode = extendedPythonGenerator.workspaceToCode(this.blocklyWorkspace);
-    const exportedBlocks = JSON.stringify(extendedPythonGenerator.getExportedBlocks(this.blocklyWorkspace));
+    const pythonCode = extendedPythonGenerator.workspaceToCode(this.blocklyWorkspace, this.generatorContext);
+    const exportedBlocks = JSON.stringify(this.generatorContext.getExportedBlocks());
     const blocksContent = JSON.stringify(Blockly.serialization.workspaces.save(this.blocklyWorkspace));
     return commonStorage.makeModuleContent(this.currentModule, pythonCode, exportedBlocks, blocksContent);
   }

--- a/src/editor/generator_context.ts
+++ b/src/editor/generator_context.ts
@@ -1,0 +1,109 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @author lizlooney@google.com (Liz Looney)
+ */
+
+import { Block } from "../toolbox/items";
+import * as commonStorage from '../storage/common_storage';
+
+
+export function createGeneratorContext(): GeneratorContext {
+  return new GeneratorContext();
+}
+
+export class GeneratorContext {
+  private module: commonStorage.Module | null = null;
+
+  // The exported blocks for the current module.
+  private exportedBlocks: Block[] = [];
+
+  // Key is the mrc_class_method_def block's NAME field, value is the python method name.
+  private classMethodNames: {[key: string]: string} = Object.create(null);
+
+  setModule(module: commonStorage.Module | null) {
+    this.module = module;
+    this.clear();
+  }
+
+  clear(): void {
+    this.clearExportedBlocks();
+    this.clearClassMethodNames();
+  }
+
+  getClassName(): string {
+    if (this.module.moduleType === commonStorage.MODULE_TYPE_PROJECT) {
+      return 'Robot';
+    }
+
+    // TODO(lizlooney): className should be a field in commonStorage.Module.
+    // Until that happens, we'll figure it out now from the module name.
+
+    let className = '';
+    let nextCharUpper = true;
+    for (let i = 0; i < this.module.moduleName.length; i++) {
+      const char = this.module.moduleName.charAt(i);
+      if (char !== '_') {
+        className += nextCharUpper ? char.toUpperCase() : char;
+      }
+      nextCharUpper = (char === '_');
+    }
+    return className;
+  }
+
+  getClassParent(): string {
+    if (this.module.moduleType === commonStorage.MODULE_TYPE_PROJECT) {
+      return 'RobotBase';
+    }
+    if (this.module.moduleType === commonStorage.MODULE_TYPE_OPMODE) {
+      return 'OpMode';
+    }
+    if (this.module.moduleType === commonStorage.MODULE_TYPE_MECHANISM) {
+      return 'Mechanism';
+    }
+    return '';
+  }
+
+  clearExportedBlocks() {
+    this.exportedBlocks.length = 0;
+  }
+
+  setExportedBlocks(exportedBlocks: Blocks[]) {
+    this.exportedBlocks.length = 0;
+    this.exportedBlocks.push(...exportedBlocks);
+  }
+
+  getExportedBlocks(): Block[] {
+    return this.exportedBlocks;
+  }
+
+  clearClassMethodNames() {
+    this.classMethodNames = Object.create(null);
+  }
+
+  addClassMethodName(nameFieldValue: string, methodName: string) {
+    this.classMethodNames[nameFieldValue] = methodName;
+  }
+
+  getClassMethodName(nameFieldValue: string): string | null {
+    if (nameFieldValue in this.classMethodNames) {
+      return this.classMethodNames[nameFieldValue];
+    }
+    return null;
+  }
+}

--- a/src/editor/generator_context.ts
+++ b/src/editor/generator_context.ts
@@ -97,13 +97,15 @@ export class GeneratorContext {
   }
 
   addClassMethodName(nameFieldValue: string, methodName: string) {
-    this.classMethodNames[nameFieldValue] = methodName;
+    if (nameFieldValue !== methodName) {
+      this.classMethodNames[nameFieldValue] = methodName;
+    }
   }
 
   getClassMethodName(nameFieldValue: string): string | null {
-    if (nameFieldValue in this.classMethodNames) {
+    if (this.classMethodNames[nameFieldValue]) {
       return this.classMethodNames[nameFieldValue];
     }
-    return null;
+    return nameFieldValue;
   }
 }


### PR DESCRIPTION
Fixed #63

Added generator_context.ts with class GeneratorContext, which holds information needed during and after python code generation:
- The module (so the ExtendedPythonGenerator can get the class and parent class names)
- Exported blocks (these are produced by the ExtendedPythonGenerator and are added to the file after code generation is finished).
- The class method names (maps from the block's NAME field to the actual python method name)
- Method getClassName returns the class name as PascalCase.

Modified ExtendedPythonGenerator so it can safely be a singleton.
- Removed fields currentModule and mapWorkspaceIdToExportedBlocks and added context (type GeneratorContext).
- Renamed methods_ field to classMethods. This field can stay in ExtendedPythonGenerator because it is only needed during workspaceToCode execution. It is not needed after workspaceToCode has finished.
- Added a field name workspace for the Blockly Workspace because it is needed in the finish method, but it is not a parameter.
- Removed init method override.
- Added workspaceToCode overload with additional parameter context (type GeneratorContext).
- Renamed method addMethod to addClassMethodDefinition and added NAME field value as a parameter.
- Added finish method override. --  Here we still produce the code, which is the class definition line and the class method definitions. --  By setting the code parameter to the code we want (the class definition) and passing it to super.finish, we can just call super.finish normally. --  Produce the exported blocks.
- Moved setCurrentModule (renamed to setModule), getExportedBlocks, and classParentFromModuleType (renamed to getClassParent) to GeneratorContext.

Updated the App to create a GeneratorContext and pass it to workspaceToCode. Updated common_storage to create a GeneratorContext and pass it to workspaceToCode. Updated Editor to create a GeneratorContext and pass it to workspaceToCode.

Modified code generator for mrc_class_method_def blocks to return empty string.