### PR TITLE
Handle method names that are python reserved words.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,4 @@ WARNING! This is not ready for use and is under heavy development of basic featu
 2. Mechanisms aren't limited to only Robot or Mechanism class
 3. No way to specify whether an opmode is auto or teleop
 4. Since we changed the "Workspace" terminology to "Project", existing Workspaces are no longer supported. They can be deleted via the browser's Developer Tools - Application tab.
+5. When a method definition block's name or parameters are changed, the call blocks don't update automatically.

--- a/src/editor/editor.ts
+++ b/src/editor/editor.ts
@@ -50,7 +50,7 @@ export class Editor {
     this.blocklyWorkspace = blocklyWorkspace;
     this.generatorContext = generatorContext;
     this.storage = storage;
-    this.methodsCategory = new MethodsCategory(blocklyWorkspace);
+    this.methodsCategory = new MethodsCategory(blocklyWorkspace, generatorContext);
   }
 
   private onChangeWhileLoading(event: Blockly.Events.Abstract) {
@@ -112,7 +112,6 @@ export class Editor {
   public async loadModuleBlocks(currentModule: commonStorage.Module | null) {
     this.generatorContext.setModule(currentModule);
     this.currentModule = currentModule;
-    this.methodsCategory.setCurrentModule(currentModule);
     if (currentModule) {
       this.modulePath = currentModule.modulePath;
       this.projectPath = commonStorage.makeProjectPath(currentModule.projectName);
@@ -226,5 +225,4 @@ export class Editor {
       throw e;
     }
   }
-
 }


### PR DESCRIPTION
The code generated for blocks that call methods defined in the same module match the method definition blocks. For example, if you create a method named "raise" and you drop a call block for it on the same blockly workspace, the python code for both the definition and the call will be "raise2".

Added known issue to readme: renaming a method definition doesn't update call blocks.

Fixes #73 
