### PR TITLE
Make all variables class instance variables

### DIFF
--- a/src/blocks/mrc_class_method_def.ts
+++ b/src/blocks/mrc_class_method_def.ts
@@ -24,6 +24,8 @@ import { MRC_STYLE_CLASS_BLOCKS } from '../themes/styles';
 import { createFieldNonEditableText } from '../fields/FieldNonEditableText'
 import * as ChangeFramework from './utils/change_framework'
 import { getLegalName } from './utils/python';
+import { Order } from 'blockly/python';
+import { ExtendedPythonGenerator } from '../editor/extended_python_generator';
 
 export const BLOCK_NAME = 'mrc_class_method_def';
 
@@ -351,10 +353,6 @@ export const setup = function() {
   Blockly.Blocks[PARAM_CONTAINER_BLOCK_NAME] = METHOD_PARAM_CONTAINER;
 };
 
-import { Order } from 'blockly/python';
-import { ExtendedPythonGenerator } from '../editor/extended_python_generator';
-
-
 export const pythonFromBlock = function (
     block: ClassMethodDefBlock,
     generator: ExtendedPythonGenerator,
@@ -394,7 +392,7 @@ export const pythonFromBlock = function (
         xfix2 = xfix1;
     }
     if(block.mrcPythonMethodName == '__init__'){
-        branch = generator.INDENT + "self.mechanisms = []\n" + branch;
+        branch = generator.defineClassVariables(block.workspace) + branch;
     }    
     if (returnValue) {
         returnValue = generator.INDENT + 'return ' + returnValue + '\n';

--- a/src/blocks/mrc_mechanism.ts
+++ b/src/blocks/mrc_mechanism.ts
@@ -118,7 +118,6 @@ export const setup = function () {
   Blockly.Blocks[BLOCK_NAME] = MECHANISM_FUNCTION;
 }
 
-//TODO: This needs to cause our own init to create the mechanisms line
 export const pythonFromBlock = function (
   mechanismBlock: MechanismBlock,
   generator: ExtendedPythonGenerator,
@@ -126,9 +125,9 @@ export const pythonFromBlock = function (
   if (mechanismBlock.mrcImportModule) {
     generator.addImport(mechanismBlock.mrcImportModule);
   }
+  generator.setHasMechanism();
   let code = 'self.mechanisms["' + mechanismBlock.getFieldValue('NAME') + '"] = '
     + mechanismBlock.getFieldValue('TYPE') + '('
-
   for (let i = 0; i < mechanismBlock.mrcArgs.length; i++) {
       const fieldName = 'ARG' + i;
       if(i != 0){

--- a/src/blocks/setup_custom_blocks.ts
+++ b/src/blocks/setup_custom_blocks.ts
@@ -1,4 +1,3 @@
-import * as Blockly from 'blockly';
 
 import * as CallPythonFunction from './mrc_call_python_function';
 import * as GetPythonEnumValue from './mrc_get_python_enum_value';

--- a/src/editor/extended_python_generator.ts
+++ b/src/editor/extended_python_generator.ts
@@ -39,6 +39,38 @@ export class ExtendedPythonGenerator extends PythonGenerator {
     super('Python');
   }
 
+  init(workspace: Blockly.Workspace){
+    super.init(workspace);
+    // This will have all variables in the defintion 'variables' so we will need to destroy it and make our own
+    delete this.definitions_['variables'];
+
+    const defvars = [];
+    // Add developer variables (not created or named by the user).
+    const devVarList = Blockly.Variables.allDeveloperVariables(workspace);
+    for (let i = 0; i < devVarList.length; i++) {
+      defvars.push(
+        this.nameDB_!.getName(devVarList[i], Blockly.Names.DEVELOPER_VARIABLE_TYPE) + ' = None',
+      );
+    }
+    this.definitions_['variables'] = defvars.join('\n');     
+    // user variables are dealt with in init code generation
+  }
+
+  defineClassVariables(workspace: Blockly.Workspace) : string{
+      const classVars = Blockly.Variables.allUsedVarModels(workspace);
+
+      let variableDefinitions = '';
+      
+      for (let i = 0; i < classVars.length; i++) {
+          variableDefinitions += this.INDENT + this.getVariableName(classVars[i].getId()) + ' = None\n';
+      }
+      return variableDefinitions;
+  }
+  getVariableName(name : string) : string{
+    const varName = super.getVariableName(name);
+    return "self." + varName;
+  }
+
   workspaceToCode(workspace: Blockly.Workspace, context: GeneratorContext): string {
     this.workspace = workspace;
     this.context = context;

--- a/src/editor/extended_python_generator.ts
+++ b/src/editor/extended_python_generator.ts
@@ -57,13 +57,8 @@ export class ExtendedPythonGenerator extends PythonGenerator {
   }
 
   defineClassVariables(workspace: Blockly.Workspace) : string{
-      const classVars = Blockly.Variables.allUsedVarModels(workspace);
-
       let variableDefinitions = '';
-      
-      for (let i = 0; i < classVars.length; i++) {
-          variableDefinitions += this.INDENT + this.getVariableName(classVars[i].getId()) + ' = None\n';
-      }
+
       if (this.context?.getHasMechanisms()){
         variableDefinitions += this.INDENT + "self.mechanisms = []\n";
       }

--- a/src/editor/extended_python_generator.ts
+++ b/src/editor/extended_python_generator.ts
@@ -64,13 +64,19 @@ export class ExtendedPythonGenerator extends PythonGenerator {
       for (let i = 0; i < classVars.length; i++) {
           variableDefinitions += this.INDENT + this.getVariableName(classVars[i].getId()) + ' = None\n';
       }
+      if (this.context?.getHasMechanisms()){
+        variableDefinitions += this.INDENT + "self.mechanisms = []\n";
+      }
       return variableDefinitions;
   }
   getVariableName(name : string) : string{
     const varName = super.getVariableName(name);
     return "self." + varName;
   }
-
+  setHasMechanism() : void{
+    this.context?.setHasMechanism();
+  }
+  
   workspaceToCode(workspace: Blockly.Workspace, context: GeneratorContext): string {
     this.workspace = workspace;
     this.context = context;

--- a/src/editor/extended_python_generator.ts
+++ b/src/editor/extended_python_generator.ts
@@ -41,7 +41,7 @@ export class ExtendedPythonGenerator extends PythonGenerator {
 
   init(workspace: Blockly.Workspace){
     super.init(workspace);
-    // This will have all variables in the defintion 'variables' so we will need to destroy it and make our own
+    // This will have all variables in the definition 'variables' so we will need to make it contain only the developer variables
     delete this.definitions_['variables'];
 
     const defvars = [];
@@ -53,9 +53,12 @@ export class ExtendedPythonGenerator extends PythonGenerator {
       );
     }
     this.definitions_['variables'] = defvars.join('\n');     
-    // user variables are dealt with in init code generation
   }
 
+  /* 
+   * This is called from the python generator for the mrc_class_method_def for the
+   * init method
+   */
   defineClassVariables(workspace: Blockly.Workspace) : string{
       let variableDefinitions = '';
 
@@ -64,7 +67,7 @@ export class ExtendedPythonGenerator extends PythonGenerator {
       }
       return variableDefinitions;
   }
-  getVariableName(name : string) : string{
+  getVariableName(nameOrId : string) : string{
     const varName = super.getVariableName(name);
     return "self." + varName;
   }

--- a/src/editor/generator_context.ts
+++ b/src/editor/generator_context.ts
@@ -36,6 +36,9 @@ export class GeneratorContext {
   // Key is the mrc_class_method_def block's NAME field, value is the python method name.
   private classMethodNames: {[key: string]: string} = Object.create(null);
 
+  // Has mechanisms (ie, needs in init)
+  private hasMechanisms = false;
+
   setModule(module: commonStorage.Module | null) {
     this.module = module;
     this.clear();
@@ -44,6 +47,13 @@ export class GeneratorContext {
   clear(): void {
     this.clearExportedBlocks();
     this.clearClassMethodNames();
+    this.hasMechanisms = false;
+  }
+  setHasMechanism():void{
+    this.hasMechanisms = true;
+  }
+  getHasMechanisms():boolean{
+    return this.hasMechanisms;
   }
 
   getClassName(): string {


### PR DESCRIPTION
Fixes #29

This was the simplest way I could come up with to make all variables part of the class (using self.).  It allows us to use all the normal built-in blockly things instead of needing to duplicate them.
