### PR TITLE
Handle method names that are python reserved words.

### DIFF
--- a/src/blocks/mrc_call_python_function.ts
+++ b/src/blocks/mrc_call_python_function.ts
@@ -48,7 +48,7 @@ export type FunctionArg = {
   type: string,
 };
 
-type CallPythonFunctionBlock = Blockly.Block & CallPythonFunctionMixin;
+export type CallPythonFunctionBlock = Blockly.Block & CallPythonFunctionMixin;
 interface CallPythonFunctionMixin extends CallPythonFunctionMixinType {
   mrcFunctionKind: FunctionKind,
   mrcReturnType: string,
@@ -57,6 +57,7 @@ interface CallPythonFunctionMixin extends CallPythonFunctionMixinType {
   mrcImportModule: string,
   mrcActualFunctionName: string,
   mrcExportedFunction: boolean,
+  maybeRenameProcedure(this: CallPythonFunctionBlock, oldName: string, legalName: string): void;
 }
 type CallPythonFunctionMixinType = typeof CALL_PYTHON_FUNCTION;
 
@@ -263,6 +264,13 @@ const CALL_PYTHON_FUNCTION = {
         input.setCheck(getAllowedTypesForSetCheck(this.mrcArgs[i].type));
       }
     }
+  },
+  maybeRenameProcedure: function(this: CallPythonFunctionBlock, oldName: string, newName: string): void {
+    if (this.mrcFunctionKind === FunctionKind.INSTANCE_WITHIN) {
+      if (this.getFieldValue(pythonUtils.FIELD_FUNCTION_NAME) == oldName) {
+        this.setFieldValue(newName, pythonUtils.FIELD_FUNCTION_NAME);
+      }
+    }
   }
 };
 
@@ -315,10 +323,8 @@ export const pythonFromBlock = function(
       break;
     }
     case FunctionKind.INSTANCE_WITHIN: {
-      const callPythonFunctionBlock = block as CallPythonFunctionBlock;
-      const functionName = (callPythonFunctionBlock.mrcActualFunctionName)
-          ? callPythonFunctionBlock.mrcActualFunctionName
-          : block.getFieldValue(pythonUtils.FIELD_FUNCTION_NAME);
+      const blocklyName = block.getFieldValue(pythonUtils.FIELD_FUNCTION_NAME);
+      const functionName = generator.getProcedureName(blocklyName);
       code = 'self.' + functionName;
       break;
     }

--- a/src/blocks/mrc_class_method_def.ts
+++ b/src/blocks/mrc_class_method_def.ts
@@ -421,7 +421,7 @@ export const pythonFromBlock = function (
         xfix2 +
         returnValue;
     code = generator.scrub_(block, code);
-    generator.addClassMethodDefinition(block.getFieldValue('NAME'), funcName, code);
+    generator.addClassMethodDefinition(funcName, code);
 
     return '';
 }

--- a/src/editor/extended_python_generator.ts
+++ b/src/editor/extended_python_generator.ts
@@ -97,8 +97,7 @@ export class ExtendedPythonGenerator extends PythonGenerator {
   /**
    * Add a class method definition.
    */
-  addClassMethodDefinition(nameFieldValue: string, methodName: string, code: string): void {
-    this.context.addClassMethodName(nameFieldValue, methodName);
+  addClassMethodDefinition(methodName: string, code: string): void {
     this.classMethods[methodName] = code;
   }
 

--- a/src/editor/generator_context.ts
+++ b/src/editor/generator_context.ts
@@ -33,9 +33,6 @@ export class GeneratorContext {
   // The exported blocks for the current module.
   private exportedBlocks: Block[] = [];
 
-  // Key is the mrc_class_method_def block's NAME field, value is the python method name.
-  private classMethodNames: {[key: string]: string} = Object.create(null);
-
   // Has mechanisms (ie, needs in init)
   private hasMechanisms = false;
 
@@ -46,15 +43,14 @@ export class GeneratorContext {
 
   clear(): void {
     this.clearExportedBlocks();
-    this.clearClassMethodNames();
     this.hasMechanisms = false;
   }
+
   setHasMechanism():void{
     this.hasMechanisms = true;
   }
   getHasMechanisms():boolean{
     return this.hasMechanisms;
-  }
 
   getClassName(): string {
     if (this.module.moduleType === commonStorage.MODULE_TYPE_PROJECT) {
@@ -100,22 +96,5 @@ export class GeneratorContext {
 
   getExportedBlocks(): Block[] {
     return this.exportedBlocks;
-  }
-
-  clearClassMethodNames() {
-    this.classMethodNames = Object.create(null);
-  }
-
-  addClassMethodName(nameFieldValue: string, methodName: string) {
-    if (nameFieldValue !== methodName) {
-      this.classMethodNames[nameFieldValue] = methodName;
-    }
-  }
-
-  getClassMethodName(nameFieldValue: string): string | null {
-    if (this.classMethodNames[nameFieldValue]) {
-      return this.classMethodNames[nameFieldValue];
-    }
-    return nameFieldValue;
   }
 }

--- a/src/editor/generator_context.ts
+++ b/src/editor/generator_context.ts
@@ -49,8 +49,10 @@ export class GeneratorContext {
   setHasMechanism():void{
     this.hasMechanisms = true;
   }
+
   getHasMechanisms():boolean{
     return this.hasMechanisms;
+  }
 
   getClassName(): string {
     if (this.module.moduleType === commonStorage.MODULE_TYPE_PROJECT) {

--- a/src/toolbox/methods_category.ts
+++ b/src/toolbox/methods_category.ts
@@ -118,7 +118,6 @@ export class MethodsCategory {
             functionKind: 'instance_within',
             returnType: classMethodDefBlock.mrcReturnType,
             args: [],
-            actualFunctionName: classMethodDefBlock.mrcPythonMethodName,
           },
           fields: {
             FUNC: classMethodDefBlock.getFieldValue('NAME'),


### PR DESCRIPTION
Handle method names that are python reserved words.
Fixes #73   

Update mrc_call_python_function blocks in the same blockly workspace when the method name on a mrc_class_method_def block is changed.
(This does not close 71 because does not update callers if a parameter or the return type changes.