### PR TITLE
Ask for class name (instead of module/file name) in dialog boxes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,7 +43,9 @@ import * as Blockly from 'blockly/core';
 import {pythonGenerator} from 'blockly/python';
 
 import BlocklyComponent from './Blockly';
+
 import { NewProjectNameModalProps, NewProjectNameModal } from './modal/NewProjectNameModal';
+import { NewModuleNameModalProps, NewModuleNameModal } from './modal/NewModuleNameModal';
 
 import * as CustomBlocks from './blocks/setup_custom_blocks';
 import { initialize as initializeGeneratedBlocks } from './blocks/utils/generated/initialize';
@@ -63,89 +65,6 @@ import * as commonStorage from './storage/common_storage';
 import * as ChangeFramework from './blocks/utils/change_framework'
 import {mutatorOpenListener}  from './blocks/mrc_class_method_def'
 
-
-type NewModuleNameModalProps = {
-  title: string;
-  isOpen: boolean;
-  initialValue: string;
-  getCurrentProjectName: () => string;
-  getModuleNames: (projectName: string) => string[];
-  onOk: (newName: string) => void;
-  onCancel: () => void;
-}
-
-const NewModuleNameModal: React.FC<NewModuleNameModalProps> = ({ title, isOpen, initialValue, getCurrentProjectName, getModuleNames, onOk, onCancel }) => {
-  const inputRef = useRef<InputRef>(null);
-  const [value, setValue] = useState('');
-  const [projectName, setProjectName] = useState('');
-  const [moduleNames, setModuleNames] = useState<string[]>([]);
-  const [alertErrorMessage, setAlertErrorMessage] = useState('');
-  const [alertErrorVisible, setAlertErrorVisible] = useState(false);
-
-  const afterOpenChange = (open: boolean) => {
-    if (open) {
-      setValue(initialValue);
-      const currentProjectName = getCurrentProjectName();
-      setProjectName(currentProjectName);
-      setModuleNames(getModuleNames(currentProjectName));
-      if (inputRef.current) {
-        inputRef.current.focus();
-      }
-    } else {
-      setValue('');
-    }
-  };
-
-  const handleOk = () => {
-    if (!commonStorage.isValidPythonModuleName(value)) {
-      setAlertErrorMessage(value + ' is not a valid blocks module name');
-      setAlertErrorVisible(true);
-      return;
-    }
-    if (projectName === value) {
-      setAlertErrorMessage('The project is already named ' + value);
-      setAlertErrorVisible(true);
-      return;
-    }
-    if (moduleNames.includes(value)) {
-      setAlertErrorMessage('Another module is already named ' +  value);
-      setAlertErrorVisible(true);
-      return;
-    }
-    onOk(value);
-  };
-
-  return (
-    <Modal
-      title={title}
-      open={isOpen}
-      afterOpenChange={afterOpenChange}
-      onCancel={onCancel}
-      footer={[
-        <Button key="cancel" onClick={onCancel}> Cancel </Button>,
-        <Button key="ok" onClick={handleOk}> OK </Button>
-      ]}
-    >
-      <Flex vertical gap="small">
-        <Typography.Paragraph> Name </Typography.Paragraph>
-        <Input
-          ref={inputRef}
-          value={value}
-          onPressEnter={handleOk}
-          onChange={(e) => setValue(e.target.value.toLowerCase())}
-        />
-        {alertErrorVisible && (
-          <Alert
-            type="error"
-            message={alertErrorMessage}
-            closable
-            afterClose={() => setAlertErrorVisible(false)}
-          />
-        )}
-      </Flex>
-    </Modal>
-  );
-};
 
 type BlocklyComponentType = {
   getBlocklyWorkspace: () => Blockly.WorkspaceSvg,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,9 +40,10 @@ import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { dracula } from 'react-syntax-highlighter/dist/esm/styles/prism';
 
 import * as Blockly from 'blockly/core';
-import {pythonGenerator} from 'blockly/python'
+import {pythonGenerator} from 'blockly/python';
 
 import BlocklyComponent from './Blockly';
+import { NewProjectNameModalProps, NewProjectNameModal } from './modal/NewProjectNameModal';
 
 import * as CustomBlocks from './blocks/setup_custom_blocks';
 import { initialize as initializeGeneratedBlocks } from './blocks/utils/generated/initialize';
@@ -61,90 +62,6 @@ import * as commonStorage from './storage/common_storage';
 
 import * as ChangeFramework from './blocks/utils/change_framework'
 import {mutatorOpenListener}  from './blocks/mrc_class_method_def'
-
-
-type NewProjectNameModalProps = {
-  title: string;
-  isOpen: boolean;
-  initialValue: string;
-  getProjectNames: () => string[];
-  onOk: (newName: string) => void;
-  onCancel: () => void;
-}
-
-const NewProjectNameModal: React.FC<NewProjectNameModalProps> = ({ title, isOpen, initialValue, getProjectNames, onOk, onCancel }) => {
-  const inputRef = useRef<InputRef>(null);
-  const [message, setMessage] = useState('');
-  const [value, setValue] = useState('');
-  const [projectNames, setProjectNames] = useState<string[]>([]);
-  const [alertErrorMessage, setAlertErrorMessage] = useState('');
-  const [alertErrorVisible, setAlertErrorVisible] = useState(false);
-
-  const afterOpenChange = (open: boolean) => {
-    if (open) {
-      setValue(initialValue);
-      const w = getProjectNames();
-      if (w.length === 0) {
-        setMessage('Let\'s create your first project. You just need to give it a name.');
-      }
-      setProjectNames(w);
-      if (inputRef.current) {
-        inputRef.current.focus();
-      }
-    } else {
-      setValue('');
-      setMessage('');
-    }
-  };
-
-  const handleOk = () => {
-    if (!commonStorage.isValidPythonModuleName(value)) {
-      setAlertErrorMessage(value + ' is not a valid blocks module name');
-      setAlertErrorVisible(true);
-      return;
-    }
-    if (projectNames.includes(value)) {
-      setAlertErrorMessage('There is already a project named ' +  value);
-      setAlertErrorVisible(true);
-      return;
-    }
-    onOk(value);
-  };
-
-  return (
-    <Modal
-      title={title}
-      open={isOpen}
-      afterOpenChange={afterOpenChange}
-      onCancel={onCancel}
-      footer={[
-        <Button key="cancel" onClick={onCancel}> Cancel </Button>,
-        <Button key="ok" onClick={handleOk}> OK </Button>
-      ]}
-    >
-      <Flex vertical gap="small">
-        <Typography.Paragraph
-          style={message.length === 0 ? { display: 'none' } : { }}
-        >{message}</Typography.Paragraph>
-        <Typography.Paragraph> Project Name </Typography.Paragraph>
-        <Input
-          ref={inputRef}
-          value={value}
-          onPressEnter={handleOk}
-          onChange={(e) => setValue(e.target.value.toLowerCase())}
-        />
-        {alertErrorVisible && (
-          <Alert
-            type="error"
-            message={alertErrorMessage}
-            closable
-            afterClose={() => setAlertErrorVisible(false)}
-          />
-        )}
-      </Flex>
-    </Modal>
-  );
-};
 
 
 type NewModuleNameModalProps = {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -263,7 +263,7 @@ const App: React.FC = () => {
       });
       const parent: TreeDataNode = {
         key: project.modulePath,
-        title: project.projectName,
+        title: project.className,
         children: children,
         icon: <ProjectOutlined />,
       };
@@ -437,6 +437,14 @@ const App: React.FC = () => {
     });
   };
 
+  const getProjectClassNames = (): string[] => {
+    const projectClassNames: string[] = [];
+    modules.forEach((project) => {
+      projectClassNames.push(project.className);
+    });
+    return projectClassNames;
+  };
+
   const getProjectNames = (): string[] => {
     const projectNames: string[] = [];
     modules.forEach((project) => {
@@ -445,10 +453,12 @@ const App: React.FC = () => {
     return projectNames;
   };
 
-  const handleNewProjectNameOk = async (newProjectName: string) => {
+  const handleNewProjectNameOk = async (newProjectClassName: string) => {
+    const newProjectName = commonStorage.classNameToModuleName(newProjectClassName);
     const newProjectPath = commonStorage.makeProjectPath(newProjectName);
     if (newProjectNameModalPurpose === PURPOSE_NEW_PROJECT) {
-      const projectContent = commonStorage.newProjectContent(newProjectName);
+      const projectContent = commonStorage.newProjectContent(
+          newProjectClassName, newProjectName, newProjectPath);
       try {
         await storage.createModule(
             commonStorage.MODULE_TYPE_PROJECT, newProjectPath, projectContent);
@@ -1078,7 +1088,7 @@ const App: React.FC = () => {
         title={newProjectNameModalTitle}
         isOpen={newProjectNameModalIsOpen}
         initialValue={newProjectNameModalInitialValue}
-        getProjectNames={getProjectNames}
+        getProjectClassNames={getProjectClassNames}
         onOk={(newName) => {
           setNewProjectNameModalIsOpen(false);
           handleNewProjectNameOk(newName);

--- a/src/modal/NewModuleNameModal.tsx
+++ b/src/modal/NewModuleNameModal.tsx
@@ -43,8 +43,8 @@ export const TITLE_COPY_OPMODE = 'Copy OpMode';
 
 const DESCRIPTION = 'No spaces are allowed in the name. Each word in the name should start with a capital letter.';
 
-export const EXAMPLE_MECHANISM = 'For example, GamePieceShooter';
-export const EXAMPLE_OPMODE = 'For example, AutoParkAndShoot';
+export const EXAMPLE_MECHANISM = 'For example: GamePieceShooter';
+export const EXAMPLE_OPMODE = 'For example: AutoParkAndShoot';
 export const LABEL_MECHANISM = 'Mechanism Name:';
 export const LABEL_OPMODE = 'OpMode Name:';
 

--- a/src/modal/NewModuleNameModal.tsx
+++ b/src/modal/NewModuleNameModal.tsx
@@ -34,21 +34,37 @@ import type { InputRef } from 'antd';
 import * as commonStorage from '../storage/common_storage';
 
 
-export type NewModuleNameModalProps = {
+export const TITLE_NEW_MECHANISM = 'New Mechanism';
+export const TITLE_RENAME_MECHANISM = 'Rename Mechanism';
+export const TITLE_COPY_MECHANISM = 'Copy Mechanism';
+export const TITLE_NEW_OPMODE = 'New OpMode';
+export const TITLE_RENAME_OPMODE = 'Rename OpMode';
+export const TITLE_COPY_OPMODE = 'Copy OpMode';
+
+const DESCRIPTION = 'No spaces are allowed in the name. Each word in the name should start with a capital letter.';
+
+export const EXAMPLE_MECHANISM = 'For example, GamePieceShooter';
+export const EXAMPLE_OPMODE = 'For example, AutoParkAndShoot';
+export const LABEL_MECHANISM = 'Mechanism Name:';
+export const LABEL_OPMODE = 'OpMode Name:';
+
+type NewModuleNameModalProps = {
   title: string;
+  example: string;
+  label: string;
   isOpen: boolean;
   initialValue: string;
   getCurrentProjectName: () => string;
-  getModuleNames: (projectName: string) => string[];
+  getModuleClassNames: (projectName: string) => string[];
   onOk: (newName: string) => void;
   onCancel: () => void;
 }
 
-export const NewModuleNameModal: React.FC<NewModuleNameModalProps> = ({ title, isOpen, initialValue, getCurrentProjectName, getModuleNames, onOk, onCancel }) => {
+export const NewModuleNameModal: React.FC<NewModuleNameModalProps> = ({ title, example, label, isOpen, initialValue, getCurrentProjectName, getModuleClassNames, onOk, onCancel }) => {
   const inputRef = useRef<InputRef>(null);
   const [value, setValue] = useState('');
-  const [projectName, setProjectName] = useState('');
-  const [moduleNames, setModuleNames] = useState<string[]>([]);
+  const [projectClassName, setProjectClassName] = useState('');
+  const [moduleClassNames, setModuleClassNames] = useState<string[]>([]);
   const [alertErrorMessage, setAlertErrorMessage] = useState('');
   const [alertErrorVisible, setAlertErrorVisible] = useState(false);
 
@@ -56,29 +72,34 @@ export const NewModuleNameModal: React.FC<NewModuleNameModalProps> = ({ title, i
     if (open) {
       setValue(initialValue);
       const currentProjectName = getCurrentProjectName();
-      setProjectName(currentProjectName);
-      setModuleNames(getModuleNames(currentProjectName));
+      setProjectClassName(commonStorage.moduleNameToClassName(currentProjectName));
+      setModuleClassNames(getModuleClassNames(currentProjectName));
       if (inputRef.current) {
         inputRef.current.focus();
       }
     } else {
       setValue('');
+      setAlertErrorVisible(false);
     }
   };
 
+  const onChange = (e) => {
+    setValue(commonStorage.onChangeClassName(e.target.value));
+  };
+
   const handleOk = () => {
-    if (!commonStorage.isValidPythonModuleName(value)) {
-      setAlertErrorMessage(value + ' is not a valid blocks module name');
+    if (!commonStorage.isValidClassName(value)) {
+      setAlertErrorMessage(value + ' is not a valid name. Please enter a different name.');
       setAlertErrorVisible(true);
       return;
     }
-    if (projectName === value) {
-      setAlertErrorMessage('The project is already named ' + value);
+    if (projectClassName === value) {
+      setAlertErrorMessage('The project is already named ' + value + '. Please enter a different name.');
       setAlertErrorVisible(true);
       return;
     }
-    if (moduleNames.includes(value)) {
-      setAlertErrorMessage('Another module is already named ' +  value);
+    if (moduleClassNames.includes(value)) {
+      setAlertErrorMessage('Another Mechanism or OpMode is already named ' +  value + '. Please enter a different name.');
       setAlertErrorVisible(true);
       return;
     }
@@ -97,13 +118,17 @@ export const NewModuleNameModal: React.FC<NewModuleNameModalProps> = ({ title, i
       ]}
     >
       <Flex vertical gap="small">
-        <Typography.Paragraph> Name </Typography.Paragraph>
-        <Input
-          ref={inputRef}
-          value={value}
-          onPressEnter={handleOk}
-          onChange={(e) => setValue(e.target.value.toLowerCase())}
-        />
+        <Typography.Paragraph>{DESCRIPTION}</Typography.Paragraph>
+        <Typography.Paragraph>{example}</Typography.Paragraph>
+        <Flex vertical gap="0">
+          <Typography.Paragraph>{label}</Typography.Paragraph>
+          <Input
+            ref={inputRef}
+            value={value}
+            onPressEnter={handleOk}
+            onChange={onChange}
+          />
+        </Flex>
         {alertErrorVisible && (
           <Alert
             type="error"

--- a/src/modal/NewModuleNameModal.tsx
+++ b/src/modal/NewModuleNameModal.tsx
@@ -1,0 +1,118 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @author lizlooney@google.com (Liz Looney)
+ */
+
+import React, { useState, useRef } from 'react';
+
+import {
+  Alert,
+  Button,
+  Flex,
+  Input,
+  Modal,
+  Typography,
+} from 'antd';
+import type { InputRef } from 'antd';
+
+import * as commonStorage from '../storage/common_storage';
+
+
+export type NewModuleNameModalProps = {
+  title: string;
+  isOpen: boolean;
+  initialValue: string;
+  getCurrentProjectName: () => string;
+  getModuleNames: (projectName: string) => string[];
+  onOk: (newName: string) => void;
+  onCancel: () => void;
+}
+
+export const NewModuleNameModal: React.FC<NewModuleNameModalProps> = ({ title, isOpen, initialValue, getCurrentProjectName, getModuleNames, onOk, onCancel }) => {
+  const inputRef = useRef<InputRef>(null);
+  const [value, setValue] = useState('');
+  const [projectName, setProjectName] = useState('');
+  const [moduleNames, setModuleNames] = useState<string[]>([]);
+  const [alertErrorMessage, setAlertErrorMessage] = useState('');
+  const [alertErrorVisible, setAlertErrorVisible] = useState(false);
+
+  const afterOpenChange = (open: boolean) => {
+    if (open) {
+      setValue(initialValue);
+      const currentProjectName = getCurrentProjectName();
+      setProjectName(currentProjectName);
+      setModuleNames(getModuleNames(currentProjectName));
+      if (inputRef.current) {
+        inputRef.current.focus();
+      }
+    } else {
+      setValue('');
+    }
+  };
+
+  const handleOk = () => {
+    if (!commonStorage.isValidPythonModuleName(value)) {
+      setAlertErrorMessage(value + ' is not a valid blocks module name');
+      setAlertErrorVisible(true);
+      return;
+    }
+    if (projectName === value) {
+      setAlertErrorMessage('The project is already named ' + value);
+      setAlertErrorVisible(true);
+      return;
+    }
+    if (moduleNames.includes(value)) {
+      setAlertErrorMessage('Another module is already named ' +  value);
+      setAlertErrorVisible(true);
+      return;
+    }
+    onOk(value);
+  };
+
+  return (
+    <Modal
+      title={title}
+      open={isOpen}
+      afterOpenChange={afterOpenChange}
+      onCancel={onCancel}
+      footer={[
+        <Button key="cancel" onClick={onCancel}> Cancel </Button>,
+        <Button key="ok" onClick={handleOk}> OK </Button>
+      ]}
+    >
+      <Flex vertical gap="small">
+        <Typography.Paragraph> Name </Typography.Paragraph>
+        <Input
+          ref={inputRef}
+          value={value}
+          onPressEnter={handleOk}
+          onChange={(e) => setValue(e.target.value.toLowerCase())}
+        />
+        {alertErrorVisible && (
+          <Alert
+            type="error"
+            message={alertErrorMessage}
+            closable
+            afterClose={() => setAlertErrorVisible(false)}
+          />
+        )}
+      </Flex>
+    </Modal>
+  );
+};

--- a/src/modal/NewProjectNameModal.tsx
+++ b/src/modal/NewProjectNameModal.tsx
@@ -33,17 +33,20 @@ import type { InputRef } from 'antd';
 
 import * as commonStorage from '../storage/common_storage';
 
+const DESCRIPTION = 'No spaces are allowed in the project name. Each word in the project should start with a capital letter.';
+const EXAMPLE = 'For example, MyAwesomeRobot';
+
 
 export type NewProjectNameModalProps = {
   title: string;
   isOpen: boolean;
   initialValue: string;
-  getProjectNames: () => string[];
+  getProjectClassNames: () => string[];
   onOk: (newName: string) => void;
   onCancel: () => void;
 }
 
-export const NewProjectNameModal: React.FC<NewProjectNameModalProps> = ({ title, isOpen, initialValue, getProjectNames, onOk, onCancel }) => {
+export const NewProjectNameModal: React.FC<NewProjectNameModalProps> = ({ title, isOpen, initialValue, getProjectClassNames, onOk, onCancel }) => {
   const inputRef = useRef<InputRef>(null);
   const [message, setMessage] = useState('');
   const [value, setValue] = useState('');
@@ -54,7 +57,7 @@ export const NewProjectNameModal: React.FC<NewProjectNameModalProps> = ({ title,
   const afterOpenChange = (open: boolean) => {
     if (open) {
       setValue(initialValue);
-      const w = getProjectNames();
+      const w = getProjectClassNames();
       if (w.length === 0) {
         setMessage('Let\'s create your first project. You just need to give it a name.');
       }
@@ -68,9 +71,13 @@ export const NewProjectNameModal: React.FC<NewProjectNameModalProps> = ({ title,
     }
   };
 
+  const onChange = (e) => {
+    setValue(commonStorage.onChangeClassName(e.target.value));
+  };
+
   const handleOk = () => {
-    if (!commonStorage.isValidPythonModuleName(value)) {
-      setAlertErrorMessage(value + ' is not a valid blocks module name');
+    if (!commonStorage.isValidClassName(value)) {
+      setAlertErrorMessage(value + ' is not a valid blocks project name');
       setAlertErrorVisible(true);
       return;
     }
@@ -98,11 +105,13 @@ export const NewProjectNameModal: React.FC<NewProjectNameModalProps> = ({ title,
           style={message.length === 0 ? { display: 'none' } : { }}
         >{message}</Typography.Paragraph>
         <Typography.Paragraph> Project Name </Typography.Paragraph>
+        <Typography.Paragraph>{DESCRIPTION}</Typography.Paragraph>
+        <Typography.Paragraph>{EXAMPLE}</Typography.Paragraph>
         <Input
           ref={inputRef}
           value={value}
           onPressEnter={handleOk}
-          onChange={(e) => setValue(e.target.value.toLowerCase())}
+          onChange={onChange}
         />
         {alertErrorVisible && (
           <Alert

--- a/src/modal/NewProjectNameModal.tsx
+++ b/src/modal/NewProjectNameModal.tsx
@@ -33,12 +33,21 @@ import type { InputRef } from 'antd';
 
 import * as commonStorage from '../storage/common_storage';
 
-const DESCRIPTION = 'No spaces are allowed in the project name. Each word in the project should start with a capital letter.';
-const EXAMPLE = 'For example, MyAwesomeRobot';
 
+export const TITLE_WELCOME = 'Welcome to WPILib Blocks!';
+export const TITLE_NEW_PROJECT = 'New Project';
+export const TITLE_RENAME_PROJECT = 'Rename Project';
+export const TITLE_COPY_PROJECT = 'Copy Project';
 
-export type NewProjectNameModalProps = {
+export const MESSAGE_WELCOME = 'Let\'s create your first project. You just need to give it a name.';
+
+const DESCRIPTION = 'No spaces are allowed in the name. Each word in the name should start with a capital letter.';
+const EXAMPLE = 'For example, RachelTheRobot';
+const LABEL = 'Project Name:';
+
+type NewProjectNameModalProps = {
   title: string;
+  message: string;
   isOpen: boolean;
   initialValue: string;
   getProjectClassNames: () => string[];
@@ -46,9 +55,8 @@ export type NewProjectNameModalProps = {
   onCancel: () => void;
 }
 
-export const NewProjectNameModal: React.FC<NewProjectNameModalProps> = ({ title, isOpen, initialValue, getProjectClassNames, onOk, onCancel }) => {
+export const NewProjectNameModal: React.FC<NewProjectNameModalProps> = ({ title, message, isOpen, initialValue, getProjectClassNames, onOk, onCancel }) => {
   const inputRef = useRef<InputRef>(null);
-  const [message, setMessage] = useState('');
   const [value, setValue] = useState('');
   const [projectNames, setProjectNames] = useState<string[]>([]);
   const [alertErrorMessage, setAlertErrorMessage] = useState('');
@@ -58,16 +66,13 @@ export const NewProjectNameModal: React.FC<NewProjectNameModalProps> = ({ title,
     if (open) {
       setValue(initialValue);
       const w = getProjectClassNames();
-      if (w.length === 0) {
-        setMessage('Let\'s create your first project. You just need to give it a name.');
-      }
       setProjectNames(w);
       if (inputRef.current) {
         inputRef.current.focus();
       }
     } else {
       setValue('');
-      setMessage('');
+      setAlertErrorVisible(false);
     }
   };
 
@@ -77,12 +82,12 @@ export const NewProjectNameModal: React.FC<NewProjectNameModalProps> = ({ title,
 
   const handleOk = () => {
     if (!commonStorage.isValidClassName(value)) {
-      setAlertErrorMessage(value + ' is not a valid blocks project name');
+      setAlertErrorMessage(value + ' is not a valid project name. Please enter a different name.');
       setAlertErrorVisible(true);
       return;
     }
     if (projectNames.includes(value)) {
-      setAlertErrorMessage('There is already a project named ' +  value);
+      setAlertErrorMessage('There is already a project named ' +  value + '. Please enter a different name.');
       setAlertErrorVisible(true);
       return;
     }
@@ -104,15 +109,17 @@ export const NewProjectNameModal: React.FC<NewProjectNameModalProps> = ({ title,
         <Typography.Paragraph
           style={message.length === 0 ? { display: 'none' } : { }}
         >{message}</Typography.Paragraph>
-        <Typography.Paragraph> Project Name </Typography.Paragraph>
         <Typography.Paragraph>{DESCRIPTION}</Typography.Paragraph>
         <Typography.Paragraph>{EXAMPLE}</Typography.Paragraph>
-        <Input
-          ref={inputRef}
-          value={value}
-          onPressEnter={handleOk}
-          onChange={onChange}
-        />
+        <Flex vertical gap="0">
+          <Typography.Paragraph>{LABEL}</Typography.Paragraph>
+          <Input
+            ref={inputRef}
+            value={value}
+            onPressEnter={handleOk}
+            onChange={onChange}
+          />
+        </Flex>
         {alertErrorVisible && (
           <Alert
             type="error"

--- a/src/modal/NewProjectNameModal.tsx
+++ b/src/modal/NewProjectNameModal.tsx
@@ -42,7 +42,7 @@ export const TITLE_COPY_PROJECT = 'Copy Project';
 export const MESSAGE_WELCOME = 'Let\'s create your first project. You just need to give it a name.';
 
 const DESCRIPTION = 'No spaces are allowed in the name. Each word in the name should start with a capital letter.';
-const EXAMPLE = 'For example, RachelTheRobot';
+const EXAMPLE = 'For example, WackyWheelerRobot';
 const LABEL = 'Project Name:';
 
 type NewProjectNameModalProps = {

--- a/src/modal/NewProjectNameModal.tsx
+++ b/src/modal/NewProjectNameModal.tsx
@@ -1,0 +1,118 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @author lizlooney@google.com (Liz Looney)
+ */
+
+import React, { useState, useRef } from 'react';
+
+import {
+  Alert,
+  Button,
+  Flex,
+  Input,
+  Modal,
+  Typography,
+} from 'antd';
+import type { InputRef } from 'antd';
+
+import * as commonStorage from '../storage/common_storage';
+
+
+export type NewProjectNameModalProps = {
+  title: string;
+  isOpen: boolean;
+  initialValue: string;
+  getProjectNames: () => string[];
+  onOk: (newName: string) => void;
+  onCancel: () => void;
+}
+
+export const NewProjectNameModal: React.FC<NewProjectNameModalProps> = ({ title, isOpen, initialValue, getProjectNames, onOk, onCancel }) => {
+  const inputRef = useRef<InputRef>(null);
+  const [message, setMessage] = useState('');
+  const [value, setValue] = useState('');
+  const [projectNames, setProjectNames] = useState<string[]>([]);
+  const [alertErrorMessage, setAlertErrorMessage] = useState('');
+  const [alertErrorVisible, setAlertErrorVisible] = useState(false);
+
+  const afterOpenChange = (open: boolean) => {
+    if (open) {
+      setValue(initialValue);
+      const w = getProjectNames();
+      if (w.length === 0) {
+        setMessage('Let\'s create your first project. You just need to give it a name.');
+      }
+      setProjectNames(w);
+      if (inputRef.current) {
+        inputRef.current.focus();
+      }
+    } else {
+      setValue('');
+      setMessage('');
+    }
+  };
+
+  const handleOk = () => {
+    if (!commonStorage.isValidPythonModuleName(value)) {
+      setAlertErrorMessage(value + ' is not a valid blocks module name');
+      setAlertErrorVisible(true);
+      return;
+    }
+    if (projectNames.includes(value)) {
+      setAlertErrorMessage('There is already a project named ' +  value);
+      setAlertErrorVisible(true);
+      return;
+    }
+    onOk(value);
+  };
+
+  return (
+    <Modal
+      title={title}
+      open={isOpen}
+      afterOpenChange={afterOpenChange}
+      onCancel={onCancel}
+      footer={[
+        <Button key="cancel" onClick={onCancel}> Cancel </Button>,
+        <Button key="ok" onClick={handleOk}> OK </Button>
+      ]}
+    >
+      <Flex vertical gap="small">
+        <Typography.Paragraph
+          style={message.length === 0 ? { display: 'none' } : { }}
+        >{message}</Typography.Paragraph>
+        <Typography.Paragraph> Project Name </Typography.Paragraph>
+        <Input
+          ref={inputRef}
+          value={value}
+          onPressEnter={handleOk}
+          onChange={(e) => setValue(e.target.value.toLowerCase())}
+        />
+        {alertErrorVisible && (
+          <Alert
+            type="error"
+            message={alertErrorMessage}
+            closable
+            afterClose={() => setAlertErrorVisible(false)}
+          />
+        )}
+      </Flex>
+    </Modal>
+  );
+};

--- a/src/modal/NewProjectNameModal.tsx
+++ b/src/modal/NewProjectNameModal.tsx
@@ -42,7 +42,7 @@ export const TITLE_COPY_PROJECT = 'Copy Project';
 export const MESSAGE_WELCOME = 'Let\'s create your first project. You just need to give it a name.';
 
 const DESCRIPTION = 'No spaces are allowed in the name. Each word in the name should start with a capital letter.';
-const EXAMPLE = 'For example, WackyWheelerRobot';
+const EXAMPLE = 'For example: WackyWheelerRobot';
 const LABEL = 'Project Name:';
 
 type NewProjectNameModalProps = {

--- a/src/storage/client_side_storage.ts
+++ b/src/storage/client_side_storage.ts
@@ -135,12 +135,14 @@ class ClientSideStorage implements commonStorage.Storage {
           const value = cursor.value;
           const path = value.path;
           const moduleType = value.type;
+          const moduleName = commonStorage.getModuleName(path);
           const module: commonStorage.Module = {
             modulePath: path,
             moduleType: moduleType,
             projectName: commonStorage.getProjectName(path),
-            moduleName: commonStorage.getModuleName(path),
+            moduleName: moduleName,
             dateModifiedMillis: value.dateModifiedMillis,
+            className: commonStorage.moduleNameToClassName(moduleName),
           }
           if (moduleType === commonStorage.MODULE_TYPE_PROJECT) {
             const project: commonStorage.Project = {

--- a/src/storage/common_storage.ts
+++ b/src/storage/common_storage.ts
@@ -23,7 +23,7 @@ import JSZip from 'jszip';
 
 import * as Blockly from 'blockly/core';
 
-import {Block} from "../toolbox/items";
+import {Block} from '../toolbox/items';
 import startingOpModeBlocks from '../modules/opmode_start.json'; 
 import startingMechanismBlocks from '../modules/mechanism_start.json';
 import startingRobotBlocks from '../modules/robot_start.json';
@@ -39,6 +39,7 @@ export type Module = {
   projectName: string,
   moduleName: string,
   dateModifiedMillis: number,
+  className: string,
 };
 
 export type Mechanism = Module;
@@ -102,6 +103,84 @@ export function findModule(modules: Project[], modulePath: string): Module | nul
   }
 
   return null;
+}
+
+/**
+ * Makes the given name a valid class name.
+ */
+export function onChangeClassName(name: string): string {
+  let newName = '';
+
+  // Force the first character to be an upper case letter
+  let i = 0;
+  for (; i < name.length; i++) {
+    const firstChar = name.charAt(0);
+    if (firstChar >= 'A' && firstChar <= 'Z') {
+      newName += firstChar;
+      i++;
+      break;
+    } else if (firstChar >= 'a' && firstChar <= 'z') {
+      newName += firstChar.toUpperCase();
+      i++;
+      break;
+    }
+  }
+
+  for (; i < name.length; i++) {
+    const char = name.charAt(i);
+    if ((char >= 'A' && char <= 'Z') ||
+        (char >= 'a' && char <= 'z') ||
+        (char >= '0' && char <= '9')) {
+      newName += char;
+    }
+  }
+
+  return newName;
+}
+
+/**
+ * Returns true if the given name is a valid class name.
+ */
+export function isValidClassName(name: string): boolean {
+  if (name) {
+    return /^[A-Z][A-Za-z0-9]*$/.test(name);
+  }
+  return false;
+}
+
+/**
+ * Returns the module name for the given class name.
+ */
+export function classNameToModuleName(className: string): boolean {
+  let moduleName = '';
+  for (let i = 0; i < className.length; i++) {
+    const char = className.charAt(i);
+    if (char >= 'A' && char <= 'Z') {
+      if (i > 0) {
+        moduleName += '_';
+      }
+      moduleName += char.toLowerCase();
+    } else {
+      moduleName += char;
+    }
+  }
+  return moduleName;
+}
+
+/**
+ * Returns the class name for the given module name.
+ */
+export function moduleNameToClassName(moduleName: string): boolean {
+  let className = '';
+  let nextCharUpper = true;
+  for (let i = 0; i < moduleName.length; i++) {
+    const char = moduleName.charAt(i);
+    if (char !== '_') {
+      className += nextCharUpper ? char.toUpperCase() : char;
+    }
+    nextCharUpper = (char === '_');
+  }
+  return className;
 }
 
 /**
@@ -180,6 +259,7 @@ export function newProjectContent(projectName: string): string {
     projectName: projectName,
     moduleName: projectName,
     dateModifiedMillis: 0,
+    className: moduleNameToClassName(projectName),
   };
 
   return startingBlocksToModuleContent(module, startingRobotBlocks);
@@ -195,6 +275,7 @@ export function newMechanismContent(projectName: string, mechanismName: string):
     projectName: projectName,
     moduleName: mechanismName,
     dateModifiedMillis: 0,
+    className: moduleNameToClassName(mechanismName),
   };
 
   return startingBlocksToModuleContent(module, startingMechanismBlocks);
@@ -210,6 +291,7 @@ export function newOpModeContent(projectName: string, opModeName: string): strin
     projectName: projectName,
     moduleName: opModeName,
     dateModifiedMillis: 0,
+    className: moduleNameToClassName(opModeName),
   };
 
   return startingBlocksToModuleContent(module, startingOpModeBlocks);
@@ -356,6 +438,7 @@ function _processModuleContentForDownload(
     projectName: projectName,
     moduleName: moduleName,
     dateModifiedMillis: 0,
+    className: moduleNameToClassName(moduleName),
   };
 
   // Clear out the python content and exported blocks.
@@ -455,6 +538,7 @@ export function _processUploadedModule(
     projectName: projectName,
     moduleName: moduleName,
     dateModifiedMillis: 0,
+    className: moduleNameToClassName(moduleName),
   };
 
   // Generate the python content and exported blocks.


### PR DESCRIPTION
Fixes #57 
Force class names to start with uppercase letter

Fixes #75
The new Project/OpMode/Mechanism dialog should ask for the class name (PascalCase) 

Fixes #76 
The tree should show the class names not the file names

Fixes #77 
The Module class (in common_storage.ts) should have a field for className