### PR TITLE
HandleNewProject shouldn't require a project

### DIFF
--- a/src/reactComponents/ModuleOutline.tsx
+++ b/src/reactComponents/ModuleOutline.tsx
@@ -341,7 +341,7 @@ export default function ModuleOutline(props: ModuleOutlineProps) {
     }
   }
   const handleNewProjectNameOk = async (newProjectClassName: string) => {
-    if (!props.storage || !props.currentModule) {
+    if (!props.storage) {
       return;
     }
     const newProjectName = commonStorage.classNameToModuleName(newProjectClassName);


### PR DESCRIPTION
This fixes a bug where you couldn't create a new project if you didn't currently have one.  It came due to a cut/paste error when I was refactoring