### PR TITLE
Revert PR 131 because workspace.getVariableMap() doesn't return an ob…

### DIFF
--- a/src/editor/extended_python_generator.ts
+++ b/src/editor/extended_python_generator.ts
@@ -248,12 +248,12 @@ export class ExtendedPythonGenerator extends PythonGenerator {
       exportedBlocks.push(callFunctionBlock);
     }
 
-    const allVariables = workspace.getVariableMap().getAllVariables();
+    const allVariables = workspace.getAllVariables();
     for (const variableModel of allVariables) {
       // Only variables that are used outside of functions are exported. (I'm not sure if this is
       // the right choice, since all blockly variables are global variables.)
       let exported = false;
-      const variableUsesById = workspace.getVariableMap().getVariableUsesById(variableModel.getId())
+      const variableUsesById = workspace.getVariableUsesById(variableModel.getId())
       if (variableUsesById.length === 0) {
         continue;
       }


### PR DESCRIPTION
…ject that has getAllVariables or getVariableUsesById functions.