### PR TITLE
Change robot module to also use real getComponents code

### DIFF
--- a/src/toolbox/hardware_category.ts
+++ b/src/toolbox/hardware_category.ts
@@ -26,7 +26,6 @@
 
 import * as Blockly from 'blockly/core';
 
-import * as toolboxItems from './items';
 import * as commonStorage from '../storage/common_storage';
 import { getAllPossibleMechanisms } from './blocks_mechanisms';
 import { getAllPossibleComponents, getBlocks } from './blocks_components';
@@ -50,7 +49,7 @@ export function getHardwareCategory(currentModule: commonStorage.Module) {
       name: 'Hardware',
       contents: [
         getRobotMechanismsBlocks(currentModule),
-        getRobotComponentsBlocks(currentModule),
+        getComponentsBlocks(currentModule),
       ]
     };
   }


### PR DESCRIPTION
I realized that there was nothing to stop the robot module from using the same getComponents code that the mechanism module uses.