### PR TITLE
Fix static copy so attribution in About dialog works again.

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -4,14 +4,13 @@ import { defineConfig } from "vite";
 import { viteStaticCopy } from "vite-plugin-static-copy";
 import react from "@vitejs/plugin-react";
 import tsconfigPaths from "vite-tsconfig-paths";
-import path from "path";
 
 export default defineConfig({
   plugins: [react(), tsconfigPaths(), viteStaticCopy({
     targets: [
       {
-        src: path.resolve(__dirname, './oss-attribution') + '/**/*',
-        dest: "./public",
+        src: 'oss-attribution/**/*',
+        dest: "./",
       },
     ],
   }),


### PR DESCRIPTION
Somehow in the upgrading of packages, this format stopped working.   This makes the About dialog show the OSS attribution again.