### PR TITLE
Add ant design compatibility patch for working with React 19.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@ant-design/icons": "^6.0.0",
+        "@ant-design/v5-patch-for-react-19": "^1.0.3",
         "@blockly/theme-dark": "^8.0.1",
         "@tailwindcss/postcss": "^4.1.10",
         "@types/react": "^19.0.2",
@@ -181,6 +182,20 @@
       },
       "peerDependencies": {
         "react": ">=16.9.0"
+      }
+    },
+    "node_modules/@ant-design/v5-patch-for-react-19": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@ant-design/v5-patch-for-react-19/-/v5-patch-for-react-19-1.0.3.tgz",
+      "integrity": "sha512-iWfZuSUl5kuhqLUw7jJXUQFMMkM7XpW7apmKzQBQHU0cpifYW4A79xIBt9YVO5IBajKpPG5UKP87Ft7Yrw1p/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.x"
+      },
+      "peerDependencies": {
+        "antd": ">=5.22.6",
+        "react": ">=19.0.0",
+        "react-dom": ">=19.0.0"
       }
     },
     "node_modules/@asamuzakjp/css-color": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "dependencies": {
     "@ant-design/icons": "^6.0.0",
+    "@ant-design/v5-patch-for-react-19": "^1.0.3",
     "@blockly/theme-dark": "^8.0.1",
     "@tailwindcss/postcss": "^4.1.10",
     "@types/react": "^19.0.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,8 @@
  */
 import * as React from 'react';
 import * as Antd from 'antd';
+import '@ant-design/v5-patch-for-react-19';
+
 import * as Blockly from 'blockly/core';
 import {pythonGenerator} from 'blockly/python';
 


### PR DESCRIPTION
Found out (via error in javascript console) that you need the compatibility patch for antd 5.x if you are using React 19.   This is one option.  The other option is we could go back to React 18.   
