### PR TITLE
Populate the dropdown in blocks that call component instance methods

### DIFF
--- a/src/blocks/mrc_call_python_function.ts
+++ b/src/blocks/mrc_call_python_function.ts
@@ -28,6 +28,7 @@ import { getClassData, getAllowedTypesForSetCheck, getOutputCheck } from './util
 import { FunctionData, findSuperFunctionData } from './utils/python_json_types';
 import * as value from './utils/value';
 import * as variable from './utils/variable';
+import { Editor } from '../editor/editor';
 import { ExtendedPythonGenerator } from '../editor/extended_python_generator';
 import { createFieldDropdown } from '../fields/FieldDropdown';
 import { createFieldNonEditableText } from '../fields/FieldNonEditableText';
@@ -542,9 +543,13 @@ const CALL_PYTHON_FUNCTION = {
           break;
         }
         case FunctionKind.INSTANCE_COMPONENT: {
-          // TODO: We need the list of component names for this.mrcComponentClassName so we can
+          let componentNames: string[] = [];
+          // Get the list of component names whose type matches this.mrcComponentClassName so we can
           // create a dropdown that has the appropriate component names.
-          const componentNames: string[] = [];
+          const editor = Editor.getEditorForBlocklyWorkspace(this.workspace);
+          if (editor) {
+            componentNames = editor.getComponentNames(this.mrcComponentClassName);
+          }
           const componentName = this.getComponentName();
           if (!componentNames.includes(componentName)) {
             componentNames.push(componentName);

--- a/src/blocks/mrc_mechanism_component_holder.ts
+++ b/src/blocks/mrc_mechanism_component_holder.ts
@@ -25,6 +25,7 @@ import { MRC_STYLE_MECHANISMS } from '../themes/styles';
 import * as ChangeFramework from './utils/change_framework';
 import { getLegalName } from './utils/python';
 import { ExtendedPythonGenerator } from '../editor/extended_python_generator';
+import * as commonStorage from '../storage/common_storage';
 import { OUTPUT_NAME as MECHANISM_OUTPUT } from './mrc_mechanism';
 import { BLOCK_NAME as  MRC_MECHANISM_NAME } from './mrc_mechanism';
 import { BLOCK_NAME as  MRC_COMPONENT_NAME } from './mrc_component';
@@ -127,7 +128,33 @@ const MECHANISM_COMPONENT_HOLDER = {
       }
     }
   },
+  getComponents: function (this: MechanismComponentHolderBlock): commonStorage.Component[] {
+    const components: commonStorage.Component[] = []
 
+    // Get component blocks from the COMPONENTS input
+    const componentsInput = this.getInput('COMPONENTS');
+    if (componentsInput && componentsInput.connection) {
+      // Walk through all connected component blocks.
+      let componentBlock = componentsInput.connection.targetBlock();
+      while (componentBlock) {
+        if (componentBlock.type === 'mrc_component') {
+          const componentName = componentBlock.getFieldValue('NAME');
+          const componentType = componentBlock.getFieldValue('TYPE');
+
+          if (componentName && componentType) {
+            components.push({
+              name: componentName,
+              className: componentType,
+            });
+          }
+        }
+        // Move to the next block in the chain
+        componentBlock = componentBlock.getNextBlock();
+      }
+    }
+
+    return components;
+  },
 }
 
 let toolboxUpdateTimeout: NodeJS.Timeout | null = null;


### PR DESCRIPTION
Moved code that iterates through the components blocks in a holder block from hardware_category.ts to mrc_mechanism_component_holder.ts.

Added code to editor.ts to get the names of components from the robot. Added code to mrc_call_python_function.ts to populate the dropdown in blocks that call component instance methods.