### PR TITLE
Fixed problem where component.PortType was not recognized as an enum

### DIFF
--- a/src/blocks/mrc_component.ts
+++ b/src/blocks/mrc_component.ts
@@ -25,7 +25,7 @@ import { Order } from 'blockly/python';
 import { MRC_STYLE_COMPONENTS } from '../themes/styles'
 import { createFieldNonEditableText } from '../fields/FieldNonEditableText';
 import { ExtendedPythonGenerator } from '../editor/extended_python_generator';
-import { getAllowedTypesForSetCheck, getClassData, getSubclassNames } from './utils/python';
+import { getAllowedTypesForSetCheck, getClassData, getModuleData, getSubclassNames } from './utils/python';
 import * as ToolboxItems from '../toolbox/items';
 import * as CommonStorage from '../storage/common_storage';
 import { createPortShadow } from './mrc_port';
@@ -231,18 +231,18 @@ function createComponentBlock(
 }
 
 function getPortTypeForArgument(argName: string): string | null {
-  // TODO(lizlooney): Currently the JSON for component.PortType is ClassData
-  // instead of EnumData. When it is fixed to be EnumData, this code will need
-  // to be updated.
-
   const argNameLower = argName.toLowerCase();
-  const classData = getClassData('component.PortType');
-  if (classData) {
-     for (const varData of classData.classVariables) {
-       if (argNameLower === varData.name.toLowerCase()) {
-         return varData.name;
+  const moduleData = getModuleData('component');
+  for (const enumData of moduleData.enums) {
+    if (enumData.enumClassName ===  'component.PortType') {
+     for (const value of enumData.enumValues) {
+       if (argNameLower === value.toLowerCase()) {
+         return value;
        }
      }
+     break;
+    }
   }
+
   return null;
 }

--- a/src/blocks/utils/generated/external_samples_data.json
+++ b/src/blocks/utils/generated/external_samples_data.json
@@ -477,53 +477,6 @@
             "staticMethods": []
         },
         {
-            "className": "component.PortType",
-            "classVariables": [
-                {
-                    "name": "CAN_PORT",
-                    "tooltip": "",
-                    "type": "component.PortType",
-                    "writable": false
-                },
-                {
-                    "name": "I2C_PORT",
-                    "tooltip": "",
-                    "type": "component.PortType",
-                    "writable": false
-                },
-                {
-                    "name": "SERVO_PORT",
-                    "tooltip": "",
-                    "type": "component.PortType",
-                    "writable": false
-                },
-                {
-                    "name": "SMART_IO_PORT",
-                    "tooltip": "",
-                    "type": "component.PortType",
-                    "writable": false
-                },
-                {
-                    "name": "SMART_MOTOR_PORT",
-                    "tooltip": "",
-                    "type": "component.PortType",
-                    "writable": false
-                },
-                {
-                    "name": "USB_PORT",
-                    "tooltip": "",
-                    "type": "component.PortType",
-                    "writable": false
-                }
-            ],
-            "constructors": [],
-            "enums": [],
-            "instanceMethods": [],
-            "instanceVariables": [],
-            "moduleName": "component",
-            "staticMethods": []
-        },
-        {
             "className": "rev_touch_sensor.RevTouchSensor",
             "classVariables": [],
             "constructors": [
@@ -1846,7 +1799,21 @@
             "moduleVariables": []
         },
         {
-            "enums": [],
+            "enums": [
+                {
+                    "enumClassName": "component.PortType",
+                    "enumValues": [
+                        "CAN_PORT",
+                        "I2C_PORT",
+                        "SERVO_PORT",
+                        "SMART_IO_PORT",
+                        "SMART_MOTOR_PORT",
+                        "USB_PORT"
+                    ],
+                    "moduleName": "component",
+                    "tooltip": null
+                }
+            ],
             "functions": [],
             "moduleName": "component",
             "moduleVariables": []

--- a/src/blocks/utils/python.ts
+++ b/src/blocks/utils/python.ts
@@ -128,6 +128,18 @@ export function getClassData(className: string): ClassData | null {
   return null;
 }
 
+// Returns the ModuleData for the given module name.
+export function getModuleData(moduleName: string): ModuleData | null {
+  for (const pythonData of allPythonData) {
+    for (const moduleData of pythonData.modules) {
+      if (moduleData.moduleName === moduleName) {
+        return moduleData;
+      }
+    }
+  }
+  return null;
+}
+
 // If the given type is a type alias, returns the value of the type alias.
 // For example, if type is 'wpimath.units.nanoseconds', this function will return 'float'
 export function getAlias(type: string): string | null {


### PR DESCRIPTION
component.PortType is now listed as an enum in external_samples_data.json.
Updated getPortTypeForArgument in mrc_components.ts.
