### PR TITLE
Fill the Robot -> Methods category

### DIFF
--- a/src/editor/generator_context.ts
+++ b/src/editor/generator_context.ts
@@ -19,7 +19,6 @@
  * @author lizlooney@google.com (Liz Looney)
  */
 
-import { Block } from "../toolbox/items";
 import * as commonStorage from '../storage/common_storage';
 
 
@@ -29,9 +28,6 @@ export function createGeneratorContext(): GeneratorContext {
 
 export class GeneratorContext {
   private module: commonStorage.Module | null = null;
-
-  // The exported blocks for the current module.
-  private exportedBlocks: Block[] = [];
 
   // Has mechanisms (ie, needs in init)
   private hasHardware = false;
@@ -49,7 +45,6 @@ export class GeneratorContext {
   }
 
   clear(): void {
-    this.clearExportedBlocks();
     this.hasHardware= false;
   }
 
@@ -82,18 +77,5 @@ export class GeneratorContext {
       return 'Mechanism';
     }
     return '';
-  }
-
-  clearExportedBlocks() {
-    this.exportedBlocks.length = 0;
-  }
-
-  setExportedBlocks(exportedBlocks: Block[]) {
-    this.exportedBlocks.length = 0;
-    this.exportedBlocks.push(...exportedBlocks);
-  }
-
-  getExportedBlocks(): Block[] {
-    return this.exportedBlocks;
   }
 }

--- a/src/toolbox/hardware_category.ts
+++ b/src/toolbox/hardware_category.ts
@@ -21,24 +21,25 @@
 
 import * as Blockly from 'blockly/core';
 import * as commonStorage from '../storage/common_storage';
+import * as toolboxItems from './items';
 import { getAllPossibleMechanisms } from './blocks_mechanisms';
 import * as Component from '../blocks/mrc_component';
-import { getInstanceComponentBlocks } from '../blocks/mrc_call_python_function';
+import { getInstanceComponentBlocks, getInstanceRobotBlocks } from '../blocks/mrc_call_python_function';
 import { Editor } from '../editor/editor';
 
-export function getHardwareCategory(currentModule: commonStorage.Module) {
+export function getHardwareCategory(currentModule: commonStorage.Module): toolboxItems.Category {
   if (currentModule.moduleType === commonStorage.MODULE_TYPE_ROBOT) {
     return {
       kind: 'category',
       name: 'Hardware',
       contents: [
         getRobotMechanismsBlocks(currentModule),
-        getComponentsBlocks(currentModule, false),
+        getComponentsBlocks(false),
       ]
     };
   }
   if (currentModule.moduleType === commonStorage.MODULE_TYPE_MECHANISM) {
-    return getComponentsBlocks(currentModule, true);
+    return getComponentsBlocks(true);
   }
   if (currentModule.moduleType === commonStorage.MODULE_TYPE_OPMODE) {
     return {
@@ -46,22 +47,22 @@ export function getHardwareCategory(currentModule: commonStorage.Module) {
       name: 'Robot',
       contents: [
         getRobotMechanismsBlocks(currentModule),
-        getRobotComponentsBlocks(currentModule),
-        getRobotMethodsBlocks(currentModule),
+        getRobotComponentsBlocks(),
+        getRobotMethodsBlocks(),
       ]
     };
   }
   throw new Error('currentModule.moduleType has unexpected value: ' + currentModule.moduleType)
 }
 
-function getRobotMechanismsBlocks(currentModule: commonStorage.Module) {
+function getRobotMechanismsBlocks(currentModule: commonStorage.Module): toolboxItems.Category {
   // getRobotMechanismsBlocks is called when the user is editing the robot or an opmode.
   // If the user is editing the robot, it allows the user to add a mechanism to
   // the robot or use an existing mechanism.
   // If the user is editing an opmode, it allows the user to use a mechanism that
   // was previously added to the Robot.
 
-  const contents = [];
+  const contents: toolboxItems.ContentsType[] = [];
 
   // Include the "+ Mechanism" category if the user it editing the robot.
   if (currentModule.moduleType === commonStorage.MODULE_TYPE_ROBOT) {
@@ -208,13 +209,14 @@ function getRobotMechanismsBlocks(currentModule: commonStorage.Module) {
   };
 }
 
-function getRobotComponentsBlocks(currentModule: commonStorage.Module) {
+function getRobotComponentsBlocks(): toolboxItems.Category {
   // getRobotComponentsBlocks is called when the user is editing an opmode.
   // It allows the user to use a component that was previously added to the Robot.
 
-  const contents = [];
+  const contents: toolboxItems.ContentsType[] = [];
 
-  // Get the list of components from the roobt.
+  // Get the list of components from the robot and add the blocks for calling the
+  // component functions.
   const workspace = Blockly.getMainWorkspace();
   if (workspace) {
     const editor = Editor.getEditorForBlocklyWorkspace(workspace);
@@ -238,11 +240,22 @@ function getRobotComponentsBlocks(currentModule: commonStorage.Module) {
   };
 }
 
-function getRobotMethodsBlocks(currentModule: commonStorage.Module) {
-  const contents = [];
+function getRobotMethodsBlocks(): toolboxItems.Category {
+  // getRobotMethodsBlocks is called when the user is editing an opmode.
+  // It allows the user to use methods there previously defined in the Robot.
 
-  // TODO: Get the list of public methods from the robot and add the blocks for
-  // calling the robot functions to the toolbox.
+  const contents: toolboxItems.ContentsType[] = [];
+
+  // Get the list of methods from the robot and add the blocks for calling the
+  // robot functions.
+  const workspace = Blockly.getMainWorkspace();
+  if (workspace) {
+    const editor = Editor.getEditorForBlocklyWorkspace(workspace);
+    if (editor) {
+      const methodsFromRobot = editor.getMethodsFromRobot();
+      contents.push(...getInstanceRobotBlocks(methodsFromRobot));
+    }
+  }
 
   return {
     kind: 'category',
@@ -251,11 +264,11 @@ function getRobotMethodsBlocks(currentModule: commonStorage.Module) {
   };
 }
 
-function getComponentsBlocks(currentModule: commonStorage.Module, hideParams : boolean) {
+function getComponentsBlocks(hideParams : boolean): toolboxItems.Category {
   // getComponentsBlocks is called when the user is editing the robot or a
   // mechanism. It allows the user to add a component or use an existing component.
 
-  const contents = [];
+  const contents: toolboxItems.ContentsType[] = [];
 
   // Add the "+ Component" category
   contents.push({


### PR DESCRIPTION
Update the Robot -> Methods category on the toolbox when the user is editing an opmode.

Removed code that stored "exportedBlocks".