### PR TITLE
Rename

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -324,7 +324,7 @@ const App: React.FC = (): React.JSX.Element => {
     } else {
       setGeneratedCode('');
     }
-  }, [currentModule, triggerPythonRegeneration, blocklyComponent]);
+  }, [currentModule, project, triggerPythonRegeneration, blocklyComponent]);
 
   // Update toolbox when module or categories change
   React.useEffect(() => {

--- a/src/storage/common_storage.ts
+++ b/src/storage/common_storage.ts
@@ -245,6 +245,7 @@ export async function renameModuleInProject(
         mechanism.moduleName = newModuleName;
         mechanism.className = proposedClassName;
       }
+      return newModulePath;
     } else if (module.moduleType === MODULE_TYPE_OPMODE) {
       const opMode = project.opModes.find(o => o.modulePath === module.modulePath);
       if (opMode) {


### PR DESCRIPTION
This really does fix 2 issues that in our current code base.

However, it does not fix a nasty race condition when you rename an item in the tabs.   The problem is that we store the path information in multiple places.   It is in the project, but is also the "key" for each tab.   These can get out of sync such that when we go to save a module that has been renamed, it is trying to save to the old name which doesn't exist anymore.

I think this will require a pretty major change to how tabs work and I am just not fresh enough to do that right now.

A long way to say: Should we merge this in now (since it does fix 2 real issues) or should we wait until I have fixed the renaming race condition?