### PR TITLE
Updated methods_category.ts so it doesn't use implementation details of blocks

### DIFF
--- a/src/blocks/mrc_call_python_function.ts
+++ b/src/blocks/mrc_call_python_function.ts
@@ -71,10 +71,9 @@ const WARNING_ID_FUNCTION_CHANGED = 'function changed';
 export function addBuiltInFunctionBlocks(
     functions: FunctionData[],
     contents: ToolboxItems.ContentsType[]) {
-  for (const functionData of functions) {
-    const block = createBuiltInMethodBlock(functionData);
-    contents.push(block);
-  }
+  functions.forEach(functionData => {
+    contents.push(createBuiltInMethodBlock(functionData));
+  });
 }
 
 function createBuiltInMethodBlock(
@@ -132,24 +131,24 @@ export function addModuleFunctionBlocks(
     moduleName: string,
     functions: FunctionData[],
     contents: ToolboxItems.ContentsType[]) {
-  for (const functionData of functions) {
+  functions.forEach(functionData => {
     const block = createModuleFunctionOrStaticMethodBlock(
         FunctionKind.MODULE, moduleName, moduleName, functionData);
     contents.push(block);
-  }
+  });
 }
 
 export function addStaticMethodBlocks(
     importModule: string,
     functions: FunctionData[],
     contents: ToolboxItems.ContentsType[]) {
-  for (const functionData of functions) {
+  functions.forEach(functionData => {
     if (functionData.declaringClassName) {
       const block = createModuleFunctionOrStaticMethodBlock(
           FunctionKind.STATIC, importModule, functionData.declaringClassName, functionData);
       contents.push(block);
     }
-  }
+  });
 }
 
 function createModuleFunctionOrStaticMethodBlock(
@@ -176,10 +175,9 @@ export function addConstructorBlocks(
     importModule: string,
     functions: FunctionData[],
     contents: ToolboxItems.ContentsType[]) {
-  for (const functionData of functions) {
-    const block = createConstructorBlock(importModule, functionData);
-    contents.push(block);
-  }
+  functions.forEach(functionData => {
+    contents.push(createConstructorBlock(importModule, functionData));
+  });
 }
 
 function createConstructorBlock(
@@ -202,10 +200,9 @@ function createConstructorBlock(
 export function addInstanceMethodBlocks(
     functions: FunctionData[],
     contents: ToolboxItems.ContentsType[]) {
-  for (const functionData of functions) {
-    const block = createInstanceMethodBlock(functionData);
-    contents.push(block);
-  }
+  functions.forEach(functionData => {
+    contents.push(createInstanceMethodBlock(functionData));
+  });
 }
 
 function createInstanceMethodBlock(
@@ -221,6 +218,39 @@ function createInstanceMethodBlock(
   fields[FIELD_FUNCTION_NAME] = functionData.functionName;
   const inputs: {[key: string]: any} = {};
   processArgs(functionData.args, extraState, inputs, functionData.declaringClassName);
+  return createBlock(extraState, fields, inputs);
+}
+
+export function addInstanceWithinBlocks(
+    methods: CommonStorage.Method[],
+    contents: ToolboxItems.ContentsType[]) {
+  methods.forEach(method => {
+    contents.push(createInstanceWithinBlock(method));
+  });
+}
+
+function createInstanceWithinBlock(method: CommonStorage.Method): ToolboxItems.Block {
+  const extraState: CallPythonFunctionExtraState = {
+    functionKind: FunctionKind.INSTANCE_WITHIN,
+    returnType: method.returnType,
+    actualFunctionName: method.pythonName,
+    args: [],
+    classMethodDefBlockId: method.blockId,
+  };
+  const fields: {[key: string]: any} = {};
+  fields[FIELD_FUNCTION_NAME] = method.visibleName;
+  const inputs: {[key: string]: any} = {};
+  // Convert method.args from CommonStorage.MethodArg[] to ArgData[].
+  const args: ArgData[] = [];
+  // We don't include the arg for the self argument.
+  for (let i = 1; i < method.args.length; i++) {
+    args.push({
+      name: method.args[i].name,
+      type: method.args[i].type,
+      defaultValue: '',
+    });
+  }
+  processArgs(args, extraState, inputs);
   return createBlock(extraState, fields, inputs);
 }
 
@@ -276,15 +306,12 @@ function createInstanceComponentBlock(
   return createBlock(extraState, fields, inputs);
 }
 
-export function getInstanceRobotBlocks(methods: CommonStorage.Method[]): ToolboxItems.ContentsType[] {
-  const contents: ToolboxItems.ContentsType[] = [];
-
-  for (const method of methods) {
-    const block = createInstanceRobotBlock(method);
-    contents.push(block);
-  }
-
-  return contents;
+export function addInstanceRobotBlocks(
+    methods: CommonStorage.Method[],
+    contents: ToolboxItems.ContentsType[]) {
+  methods.forEach(method => {
+    contents.push(createInstanceRobotBlock(method));
+  });
 }
 
 function createInstanceRobotBlock(method: CommonStorage.Method): ToolboxItems.Block {

--- a/src/blocks/mrc_class_method_def.ts
+++ b/src/blocks/mrc_class_method_def.ts
@@ -258,9 +258,18 @@ const CLASS_METHOD_DEF = {
         }
         return legalName;
     },
-    getMethod: function (this: ClassMethodDefBlock): commonStorage.Method | null {
-      return this.mrcMethod;
-    }
+    getMethodForWithin: function (this: ClassMethodDefBlock): commonStorage.Method | null {
+        return this.mrcCanBeCalledWithinClass ? this.mrcMethod : null;
+    },
+    getMethodForOutside: function (this: ClassMethodDefBlock): commonStorage.Method | null {
+        return this.mrcCanBeCalledOutsideClass ? this.mrcMethod : null;
+    },
+    canChangeSignature: function (this: ClassMethodDefBlock): boolean {
+        return this.mrcCanChangeSignature;
+    },
+    getMethodName: function (this: ClassMethodDefBlock): string {
+        return this.getFieldValue('NAME');
+    },
 };
 
 /**
@@ -402,7 +411,7 @@ export const pythonFromBlock = function (
     code = generator.scrub_(block, code);
     generator.addClassMethodDefinition(funcName, code);
 
-    if (block.mrcCanBeCalledOutsideClass) {
+    if (block.mrcCanBeCalledWithinClass || block.mrcCanBeCalledOutsideClass) {
       // Update the mrcMethod.
       block.mrcMethod = {
         blockId: block.id,

--- a/src/toolbox/hardware_category.ts
+++ b/src/toolbox/hardware_category.ts
@@ -24,7 +24,7 @@ import * as commonStorage from '../storage/common_storage';
 import * as toolboxItems from './items';
 import { getAllPossibleMechanisms } from './blocks_mechanisms';
 import * as Component from '../blocks/mrc_component';
-import { getInstanceComponentBlocks, getInstanceRobotBlocks } from '../blocks/mrc_call_python_function';
+import { getInstanceComponentBlocks, addInstanceRobotBlocks } from '../blocks/mrc_call_python_function';
 import { Editor } from '../editor/editor';
 
 export function getHardwareCategory(currentModule: commonStorage.Module): toolboxItems.Category {
@@ -253,7 +253,7 @@ function getRobotMethodsBlocks(): toolboxItems.Category {
     const editor = Editor.getEditorForBlocklyWorkspace(workspace);
     if (editor) {
       const methodsFromRobot = editor.getMethodsFromRobot();
-      contents.push(...getInstanceRobotBlocks(methodsFromRobot));
+      addInstanceRobotBlocks(methodsFromRobot, contents);
     }
   }
 


### PR DESCRIPTION
Updated methods_category.ts so it doesn't use implementation details of mrc_class_method_def.ts and mrc_call_python_function.ts.