### PR TITLE
Add expansion hub python code.

### DIFF
--- a/external_samples/color_range_sensor.py
+++ b/external_samples/color_range_sensor.py
@@ -16,15 +16,18 @@
 # @fileoverview This is a sample for a color/range sensor
 # @author alan@porpoiseful.com (Alan Smith)
 
-from component import Component, PortType, InvalidPortException
 from typing import Protocol, Self
+from component import Component, PortType, InvalidPortException
 
 class DistanceCallable(Protocol):
     def __call__(self, distance : float) -> None:
         pass
+
+
 class ColorCallable(Protocol):
     def __call__(self, hue : int, saturation : int, value : int) -> None:
         pass
+
 
 class ColorRangeSensor(Component):    
     def __init__(self, ports : list[tuple[PortType, int]]):
@@ -32,23 +35,32 @@ class ColorRangeSensor(Component):
         if portType != PortType.I2C_PORT:
             raise InvalidPortException
         self.port = port
+
     def get_manufacturer(self) -> str:   
         return "REV Robotics" 
+
     def get_name(self) -> str:  
         return "Color Sensor v3"
+
     def get_part_number(self) -> str:  
         return "REV-31-1557"
+
     def get_url(self) -> str:  
         return "https://www.revrobotics.com/rev-31-1557"
+
     def get_version(self) -> tuple[int, int, int]: 
         return (1, 0, 0)
+
     def stop(self) -> None:
         # send stop command to sensor
         pass
+
     def reset(self) -> None:
         pass
+
     def get_connection_port_type(self) -> list[PortType]:
         return [PortType.I2C_PORT]
+
     def periodic(self) -> None:
         pass
 
@@ -62,9 +74,11 @@ class ColorRangeSensor(Component):
     def get_color_rgb(self) -> tuple[int, int, int]:
         '''gets the color in rgb (red, green, blue)'''
         pass
+
     def get_color_hsv(self) -> tuple[int, int, int]:
         '''gets the color in hsv (hue, saturation, value)'''
         pass
+
     def get_distance_mm(self) -> float:
         '''gets the distance of the object seen'''
         pass

--- a/external_samples/component.py
+++ b/external_samples/component.py
@@ -23,6 +23,8 @@ from typing import Protocol
 class EmptyCallable(Protocol):
     def __call__(self) -> None:
         pass
+
+
 class PortType(Enum):
     CAN_PORT = 1
     SMART_IO_PORT = 2
@@ -31,37 +33,44 @@ class PortType(Enum):
     I2C_PORT = 5
     USB_PORT = 6
 
+
 class InvalidPortException(Exception):
     pass
+
 
 # This is an abstract class
 class Component(ABC):
     @abstractmethod
     def __init__(self, ports : list[tuple[PortType, int]]):
         pass
-    # This is the manufacturer of the component
+
+    # Returns the manufacturer of the component
     @abstractmethod
-    def get_manufacturer(self) -> str:   
-        pass 
-    # This is the name of the component
-    @abstractmethod
-    def get_name(self) -> str:  
+    def get_manufacturer(self) -> str:
         pass
-    # This is the part number of the component
+
+    # Returns the name of the component
     @abstractmethod
-    def get_part_number(self) -> str:  
+    def get_name(self) -> str:
         pass
-    # This is the URL of the component
+
+    # Returns the part number of the component
     @abstractmethod
-    def get_url(self) -> str:  
+    def get_part_number(self) -> str:
         pass
-    # This is the version of the software (returned as a (major, minor, patch) tuple where 
+
+    # Returns the URL of the component
+    @abstractmethod
+    def get_url(self) -> str:
+        pass
+
+    # Returns the version of the software (returned as a (major, minor, patch) tuple where
     # major, minor and patch are all positive integers
     # This MUST follow semantic versioning as described here: https://semver.org/
     @abstractmethod
-    def get_version(self) -> tuple[int, int, int]: 
+    def get_version(self) -> tuple[int, int, int]:
         pass
-    
+
     # This stops all movement (if any) for the component
     @abstractmethod
     def stop(self) -> None:
@@ -73,13 +82,13 @@ class Component(ABC):
     def reset(self) -> None:
         pass
 
-    # This returns a list (can be empty, one, or multiple) of the ports this connects to
+    # Returns a list (can be empty, one, or multiple) of the ports this connects to
     # of the PortType enumeration
     @abstractmethod
     def get_connection_port_type(self) -> list[PortType]:
         pass
 
-    # This is called periodically when an opmode is running.   The component might use this
+    # This is called periodically when an opmode is running. The component might use this
     # to talk to hardware and then call callbacks
     @abstractmethod
     def periodic(self) -> None:

--- a/external_samples/rev_touch_sensor.py
+++ b/external_samples/rev_touch_sensor.py
@@ -26,24 +26,33 @@ class RevTouchSensor(Component):
         if portType != PortType.SMART_IO_PORT:
             raise InvalidPortException
         self.port = port
+
     def get_manufacturer(self) -> str:   
         return "REV Robotics" 
+
     def get_name(self) -> str:  
         return "Touch Sensor"
+
     def get_part_number(self) -> str:  
         return "REV-31-1425"
+
     def get_url(self) -> str:  
         return "https://www.revrobotics.com/rev-31-1425/"
+
     def get_version(self) -> tuple[int, int, int]: 
         return (1, 0, 0)
+
     def stop(self) -> None:
         pass
+
     def reset(self) -> None:
         self.pressed_callback = None
         self.released_callback = None
         pass
+
     def get_connection_port_type(self) -> list[PortType]:
         return [PortType.SMART_IO_PORT]
+
     def periodic(self) -> None:
         old = self.is_pressed
         self._read_hardware()

--- a/external_samples/servo.py
+++ b/external_samples/servo.py
@@ -25,23 +25,32 @@ class Servo(Component):
         if portType != PortType.SERVO_PORT:
             raise InvalidPortException
         self.port = port
+
     def get_manufacturer(self) -> str:   
         return "REV Robotics" 
+
     def get_name(self) -> str:  
         return "SRS Servo"
+
     def get_part_number(self) -> str:  
         return "REV-41-1097"
+
     def get_url(self) -> str:  
         return "https://www.revrobotics.com/rev-41-1097/"
+
     def get_version(self) -> tuple[int, int, int]: 
         return (1, 0, 0)
+
     def stop(self) -> None:
         # De-energize servo port
         pass
+
     def reset(self) -> None:
         pass
+
     def get_connection_port_type(self) -> list[PortType]:
         return [PortType.SERVO_PORT]
+
     def periodic(self) -> None:
         pass
 
@@ -56,6 +65,7 @@ class Servo(Component):
         '''Set the servo to a position between 0 and 1'''
         # sends to the hardware the position of the servo
         pass
+
     def set_angle_degrees(self, angle: float) -> None:
         '''Set the servo to an angle between 0 and 270'''
         self.set_position(angle / 270.0)

--- a/external_samples/smart_motor.py
+++ b/external_samples/smart_motor.py
@@ -25,23 +25,32 @@ class SmartMotor(Component):
         if portType != PortType.SMART_MOTOR_PORT:
             raise InvalidPortException
         self.port = port
+
     def get_manufacturer(self) -> str:   
         return "REV Robotics" 
+
     def get_name(self) -> str:  
         return "DC Motor"
+
     def get_part_number(self) -> str:  
         return "REV-xx-xxxx"
+
     def get_url(self) -> str:  
         return "https://www.revrobotics.com/rev-xx-xxxx"
+
     def get_version(self) -> tuple[int, int, int]: 
         return (1, 0, 0)
+
     def stop(self) -> None:
         # send stop command to motor
         pass
+
     def reset(self) -> None:
         pass
+
     def get_connection_port_type(self) -> list[PortType]:
         return [PortType.SMART_MOTOR_PORT]
+
     def periodic(self) -> None:
         pass
 

--- a/external_samples/spark_mini.py
+++ b/external_samples/spark_mini.py
@@ -26,7 +26,7 @@ import wpilib
 import wpimath
 import wpiutil
 
-class SparkMiniComponent(Component):
+class SparkMini(Component):
     def __init__(self, ports : list[tuple[PortType, int]]):
         portType, port = ports[0]
         if portType != PortType.SMART_MOTOR_PORT:

--- a/python_tools/generate_json.py
+++ b/python_tools/generate_json.py
@@ -53,6 +53,7 @@ import wpiutil
 # Server python scripts
 sys.path.append("../server_python_scripts")
 import blocks_base_classes
+import expansion_hub  # TODO(lizlooney): update this when it is built into robotpy.
 
 # External samples
 sys.path.append("../external_samples")
@@ -84,6 +85,7 @@ def main(argv):
   pathlib.Path(f'{FLAGS.output_directory}/generated/').mkdir(parents=True, exist_ok=True)
 
   robotpy_modules = [
+    expansion_hub,  # TODO(lizlooney): update this when it is built into robotpy.
     ntcore,
     wpilib,
     wpilib.counter,
@@ -110,16 +112,9 @@ def main(argv):
     wpinet,
     wpiutil,
   ]
-  json_generator = json_util.JsonGenerator(robotpy_modules)
+  json_generator_robotpy = json_util.JsonGenerator(robotpy_modules)
   file_path = f'{FLAGS.output_directory}/generated/robotpy_data.json'
-  json_generator.writeJsonFile(file_path)
-
-  server_python_scripts = [
-    blocks_base_classes,
-  ]
-  json_generator = json_util.JsonGenerator(server_python_scripts)
-  file_path = f'{FLAGS.output_directory}/generated/server_python_scripts.json'
-  json_generator.writeJsonFile(file_path)
+  json_generator_robotpy.writeJsonFile(file_path)
 
   external_samples_modules = [
     color_range_sensor,
@@ -130,10 +125,18 @@ def main(argv):
     spark_mini,
     sparkfun_led_stick,
   ]
-  json_generator = json_util.JsonGenerator(external_samples_modules)
+  json_generator_external_samples = json_util.JsonGenerator(
+      external_samples_modules, [json_generator_robotpy])
   file_path = f'{FLAGS.output_directory}/generated/external_samples_data.json'
-  json_generator.writeJsonFile(file_path)
+  json_generator_external_samples.writeJsonFile(file_path)
 
+  server_python_scripts = [
+    blocks_base_classes,
+  ]
+  json_generator_server_python = json_util.JsonGenerator(
+      server_python_scripts, [json_generator_robotpy])
+  file_path = f'{FLAGS.output_directory}/generated/server_python_scripts.json'
+  json_generator_server_python.writeJsonFile(file_path)
 
 if __name__ == '__main__':
   app.run(main)

--- a/python_tools/json_util.py
+++ b/python_tools/json_util.py
@@ -61,59 +61,6 @@ _KEY_ALIASES = 'aliases'
 _KEY_SUBCLASSES = 'subclasses'
 
 
-_DICT_FULL_MODULE_NAME_TO_MODULE_NAME = {
-  'blocks_base_classes.opmode': 'blocks_base_classes',
-  'blocks_base_classes.mechanism': 'blocks_base_classes',
-  'blocks_base_classes.robot_base': 'blocks_base_classes',
-
-  'hal._wpiHal': 'hal',
-  'hal.simulation._simulation': 'hal.simulation',
-
-  'ntcore._ntcore': 'ntcore',
-  'ntcore._ntcore.meta': 'ntcore.meta',
-
-  'wpilib._wpilib': 'wpilib',
-  'wpilib._wpilib.sysid': 'wpilib.sysid',
-  'wpilib.counter._counter': 'wpilib.counter',
-  'wpilib.drive._drive': 'wpilib.drive',
-  'wpilib.event._event': 'wpilib.event',
-  'wpilib.interfaces._interfaces': 'wpilib.interfaces',
-  'wpilib.shuffleboard._shuffleboard': 'wpilib.shuffleboard',
-  'wpilib.simulation._simulation': 'wpilib.simulation',
-
-  'wpimath._controls._controls.constraint': 'wpimath.trajectory.constraint',
-  'wpimath._controls._controls.controller': 'wpimath.controller',
-  'wpimath._controls._controls.estimator': 'wpimath.estimator',
-  'wpimath._controls._controls.optimization': 'wpimath.optimization',
-  'wpimath._controls._controls.path': 'wpimath.path',
-  'wpimath._controls._controls.plant': 'wpimath.system.plant',
-  'wpimath._controls._controls.system': 'wpimath.system',
-  'wpimath._controls._controls.trajectory': 'wpimath.trajectory',
-  'wpimath.filter._filter': 'wpimath.filter',
-  'wpimath.geometry._geometry': 'wpimath.geometry',
-  'wpimath.interpolation._interpolation': 'wpimath.interpolation',
-  'wpimath.kinematics._kinematics': 'wpimath.kinematics',
-  'wpimath.spline._spline': 'wpimath.spline',
-
-  'wpinet._wpinet': 'wpinet',
-
-  'wpiutil._wpiutil': 'wpiutil',
-  'wpiutil._wpiutil.log': 'wpiutil.log',
-  'wpiutil._wpiutil.sync': 'wpiutil.sync',
-  'wpiutil._wpiutil.wpistruct': 'wpiutil.wpistruct',
- }
-
-
-def getModuleName(m) -> str:
-  if inspect.ismodule(m):
-    module_name = m.__name__
-  elif isinstance(m, str):
-    module_name = m
-  else:
-    raise Exception(f'Argument m must be a module or a module name.')
-  return _DICT_FULL_MODULE_NAME_TO_MODULE_NAME.get(module_name, module_name)
-
-
 def ignoreModule(module_name: str) -> bool:
   for prefix in _LIST_MODULE_NAME_PREFIXES_TO_IGNORE:
     if module_name.startswith(prefix):
@@ -121,26 +68,57 @@ def ignoreModule(module_name: str) -> bool:
   return False
 
 
-def getClassName(c, containing_class_name: str = None) -> str:
-  if inspect.isclass(c):
-    full_class_name = python_util.getFullClassName(c)
-  elif isinstance(c, str):
-    if c == 'typing.Self' and containing_class_name:
-      full_class_name = containing_class_name
-    else:
-      full_class_name = c
-  else:
-    raise Exception(f'Argument c must be a class or a class name.')
-  for full_module_name, module_name in _DICT_FULL_MODULE_NAME_TO_MODULE_NAME.items():
-    full_class_name = full_class_name.replace(full_module_name + '.', module_name + '.')
-  return full_class_name
-
-
 class JsonGenerator:
-  def __init__(self, root_modules: list[types.ModuleType]):
+  def __init__(self, root_modules: list[types.ModuleType], libs: list = []):
     self._root_modules = root_modules
-    (self._packages, self._modules, self._classes, self._dict_full_class_name_to_alias) = python_util.collectModulesAndClasses(self._root_modules)
-    self._dict_full_class_name_to_subclass_names = python_util.collectSubclasses(self._classes)
+    (self._modules, self._classes) = python_util.collectModulesAndClasses(self._root_modules)
+    module_exports = python_util.collectModuleExports(self._modules)
+    self._type_aliases = python_util.collectTypeAliases(self._modules, self._classes)
+    self._subclasses = python_util.collectSubclasses(self._classes)
+    self._exported_class_names = {}
+    self._exported_class_module_names = {}
+    for o, module_export in module_exports.items():
+      if inspect.isclass(o):
+        full_class_name = python_util.getFullClassName(o)
+        self._exported_class_names.update({full_class_name: module_export[0]})
+        self._exported_class_module_names.update({full_class_name: module_export[1]})
+    # Copy module_exports from libs.
+    for lib in libs:
+      self._exported_class_names.update(lib._exported_class_names)
+      self._exported_class_module_names.update(lib._exported_class_module_names)
+
+  def _getModuleName(self, o) -> str:
+    if inspect.ismodule(o):
+      return o.__name__
+    if inspect.isclass(o):
+      full_class_name = python_util.getFullClassName(o)
+      if full_class_name in self._exported_class_module_names:
+        return self._exported_class_module_names[full_class_name]
+      for exported_full_class_name, exported_module_name in self._exported_class_module_names.items():
+        if full_class_name.startswith(exported_full_class_name + '.'):
+          return exported_module_name
+    if hasattr(o, '__module__'):
+      return o.__module__
+    raise Exception(f'Invalid argument {o}')
+
+  def _getClassName(self, o, containing_class_name: str = None) -> str:
+    if inspect.isclass(o):
+      full_class_name = python_util.getFullClassName(o)
+      return self._getClassName(full_class_name)
+    if isinstance(o, str):
+      if o == 'typing.Self' and containing_class_name:
+        return containing_class_name
+      if o in self._exported_class_names:
+        return self._exported_class_names[o]
+      for exported_full_class_name, exported_class_name in self._exported_class_names.items():
+        if o.find(exported_full_class_name + '.') != -1:
+          o = o.replace(exported_full_class_name + '.', exported_class_name + '.')
+        if o.find(exported_full_class_name + ']') != -1:
+          o = o.replace(exported_full_class_name + ']', exported_class_name + ']')
+        if o.find(exported_full_class_name + ',') != -1:
+          o = o.replace(exported_full_class_name + ',', exported_class_name + ',')
+      return o
+    raise Exception(f'Invalid argument {o}')
 
   def _getPublicModules(self) -> list[types.ModuleType]:
     public_modules = []
@@ -151,15 +129,13 @@ class JsonGenerator:
     public_modules.sort(key=lambda m: python_util.getFullModuleName(m))
     return public_modules
 
-
   def _createFunctionIsEnumValue(
       self, enum_cls: type) -> typing.Callable[[object], bool]:
     return lambda value: type(value) == enum_cls
 
-
   def _processModule(self, module) -> dict:
     module_data = {}
-    module_name = getModuleName(module)
+    module_name = self._getModuleName(module)
     module_data[_KEY_MODULE_NAME] = module_name
 
     # Module variables.
@@ -169,7 +145,7 @@ class JsonGenerator:
         continue
       var_data = {}
       var_data[_KEY_VARIABLE_NAME] = key
-      var_data[_KEY_VARIABLE_TYPE] = getClassName(type(value))
+      var_data[_KEY_VARIABLE_TYPE] = self._getClassName(type(value))
       var_data[_KEY_VARIABLE_WRITABLE] = python_util.isModuleVariableWritable(module, key, value)
       var_data[_KEY_TOOLTIP] = ''
       module_variables.append(var_data)
@@ -185,10 +161,10 @@ class JsonGenerator:
         declaring_module = python_util.getModule(value.__module__)
         if python_util.isBuiltInModule(declaring_module):
           # Ignore the imported function from a built-in module.
-          continue;
-        if getModuleName(declaring_module) != getModuleName(module):
+          continue
+        if self._getModuleName(declaring_module) != self._getModuleName(module):
           # Check whether the imported function is exported in __all__.
-          if not (key in module.__all__):
+          if hasattr(module, '__all__') and not (key in module.__all__):
             # Ignore the imported function.
             continue
 
@@ -217,7 +193,7 @@ class JsonGenerator:
         for i in range(len(arg_names)):
           arg_data = {}
           arg_data[_KEY_ARGUMENT_NAME] = arg_names[i]
-          arg_data[_KEY_ARGUMENT_TYPE] = getClassName(arg_types[i])
+          arg_data[_KEY_ARGUMENT_TYPE] = self._getClassName(arg_types[i])
           if arg_default_values[i] is not None:
             arg_data[_KEY_ARGUMENT_DEFAULT_VALUE] = arg_default_values[i]
           else:
@@ -225,7 +201,7 @@ class JsonGenerator:
           args.append(arg_data)
         function_data = {}
         function_data[_KEY_FUNCTION_NAME] = function_name
-        function_data[_KEY_FUNCTION_RETURN_TYPE] = getClassName(return_type)
+        function_data[_KEY_FUNCTION_RETURN_TYPE] = self._getClassName(return_type)
         function_data[_KEY_FUNCTION_ARGS] = args
         if comments[iSignature] is not None:
           function_data[_KEY_TOOLTIP] = comments[iSignature]
@@ -237,8 +213,8 @@ class JsonGenerator:
     # Enums
     enums = []
     for key, value in inspect.getmembers(module, python_util.isEnum):
-      enum_class_name = getClassName(value)
-      if getModuleName(value.__module__) != module_name:
+      enum_class_name = self._getClassName(value)
+      if self._getModuleName(value) != module_name:
         continue
       fnIsEnumValue = self._createFunctionIsEnumValue(value)
       enum_values = []
@@ -250,7 +226,7 @@ class JsonGenerator:
       enum_values.sort()
       enum_data = {}
       enum_data[_KEY_ENUM_CLASS_NAME] = enum_class_name
-      enum_data[_KEY_MODULE_NAME] = getModuleName(value.__module__)
+      enum_data[_KEY_MODULE_NAME] = self._getModuleName(value)
       enum_data[_KEY_ENUM_VALUES] = enum_values
       if enum_tooltip is not None:
         enum_data[_KEY_TOOLTIP] = enum_tooltip
@@ -260,50 +236,56 @@ class JsonGenerator:
     module_data[_KEY_ENUMS] = sorted(enums, key=lambda enum_data: enum_data[_KEY_ENUM_CLASS_NAME])
     return module_data
 
-
   def _processModules(self):
     module_data_list = []
     set_of_modules = set()
     for module in self._getPublicModules():
       set_of_modules.add(module)
     for module in set_of_modules:
-      module_name = getModuleName(module)
+      module_name = self._getModuleName(module)
       if ignoreModule(module_name):
         continue
-      #if not hasattr(module, '__all__'):
-      #  print(f'Skipping module {getModuleName(module)}')
-      #  continue
       module_data = self._processModule(module)
       module_data_list.append(module_data)
     return sorted(module_data_list, key=lambda module_data: module_data[_KEY_MODULE_NAME])
 
-
   def _getPublicClasses(self) -> list[type]:
-    public_classes = []
-    for c in self._classes:
-      class_name = getClassName(c)
+    set_of_public_classes = set()
+    for cls in self._classes:
+      class_name = self._getClassName(cls)
       if '._' in class_name:
         continue
-      public_classes.append(c)
+      for base_class in inspect.getmro(cls):
+        if python_util.isBuiltInClass(base_class):
+          break
+        base_class_name = self._getClassName(base_class)
+        if '._' in base_class_name:
+          continue
+        set_of_public_classes.add(base_class)
+    public_classes = []
+    for cls in set_of_public_classes:
+      public_classes.append(cls)
     public_classes.sort(key=lambda c: python_util.getFullClassName(c))
     return public_classes
 
-
   def _processClass(self, cls):
+    class_name = self._getClassName(cls)
     class_data = {}
-    class_name = getClassName(cls)
-    full_class_name = python_util.getFullClassName(cls)
     class_data[_KEY_CLASS_NAME] = class_name
-    class_data[_KEY_MODULE_NAME] = getModuleName(cls.__module__)
+    class_data[_KEY_MODULE_NAME] = self._getModuleName(cls)
+
+    full_class_name = python_util.getFullClassName(cls)
 
     # Class variables.
     class_variables = []
     for key, value in inspect.getmembers(cls, python_util.isNothing):
       if not python_util.isClassVariableReadable(cls, key, value):
         continue
+      if (key == "WPIStruct" and type(value).__name__ == "PyCapsule"):
+        continue;
       var_data = {}
       var_data[_KEY_VARIABLE_NAME] = key
-      var_data[_KEY_VARIABLE_TYPE] = getClassName(type(value), class_name)
+      var_data[_KEY_VARIABLE_TYPE] = self._getClassName(type(value), class_name)
       var_data[_KEY_VARIABLE_WRITABLE] = python_util.isClassVariableWritable(cls, key, value)
       var_data[_KEY_TOOLTIP] = ''
       class_variables.append(var_data)
@@ -317,7 +299,7 @@ class JsonGenerator:
       var_type = python_util.getVarTypeFromGetter(value.fget)
       var_data = {}
       var_data[_KEY_VARIABLE_NAME] = key
-      var_data[_KEY_VARIABLE_TYPE] = getClassName(var_type, class_name)
+      var_data[_KEY_VARIABLE_TYPE] = self._getClassName(var_type, class_name)
       var_data[_KEY_VARIABLE_WRITABLE] = python_util.isInstanceVariableWritable(cls, key, value)
       if value.__doc__ is not None:
         var_data[_KEY_TOOLTIP] = value.__doc__
@@ -363,12 +345,12 @@ class JsonGenerator:
           arg_type = arg_types[i]
           if i == 0 and arg_name == 'self':
             if arg_type != full_class_name:
-              declaring_class_name = getClassName(arg_type, class_name)
+              declaring_class_name = self._getClassName(arg_type, class_name)
             # Don't append the self argument to the args array.
-            continue;
+            continue
           arg_data = {}
           arg_data[_KEY_ARGUMENT_NAME] = arg_name
-          arg_data[_KEY_ARGUMENT_TYPE] = getClassName(arg_type, class_name)
+          arg_data[_KEY_ARGUMENT_TYPE] = self._getClassName(arg_type, class_name)
           if arg_default_values[i] is not None:
             arg_data[_KEY_ARGUMENT_DEFAULT_VALUE] = arg_default_values[i]
           else:
@@ -414,10 +396,10 @@ class JsonGenerator:
           if i == 0 and arg_name == 'self':
             found_self_arg = True
             if arg_type != full_class_name:
-              declaring_class_name = getClassName(arg_type, class_name)
+              declaring_class_name = self._getClassName(arg_type, class_name)
           arg_data = {}
           arg_data[_KEY_ARGUMENT_NAME] = arg_name
-          arg_data[_KEY_ARGUMENT_TYPE] = getClassName(arg_type, class_name)
+          arg_data[_KEY_ARGUMENT_TYPE] = self._getClassName(arg_type, class_name)
           if arg_default_values[i] is not None:
             arg_data[_KEY_ARGUMENT_DEFAULT_VALUE] = arg_default_values[i]
           else:
@@ -425,7 +407,7 @@ class JsonGenerator:
           args.append(arg_data)
         function_data = {}
         function_data[_KEY_FUNCTION_NAME] = function_name
-        function_data[_KEY_FUNCTION_RETURN_TYPE] = getClassName(return_type, class_name)
+        function_data[_KEY_FUNCTION_RETURN_TYPE] = self._getClassName(return_type, class_name)
         function_data[_KEY_FUNCTION_ARGS] = args
         function_data[_KEY_FUNCTION_DECLARING_CLASS_NAME] = declaring_class_name
         if comments[iSignature] is not None:
@@ -442,9 +424,9 @@ class JsonGenerator:
     # Enums
     enums = []
     for key, value in inspect.getmembers(cls, python_util.isEnum):
-      if not getClassName(value).startswith(class_name):
+      if not self._getClassName(value).startswith(class_name):
         continue
-      enum_class_name = getClassName(value)
+      enum_class_name = self._getClassName(value)
       fnIsEnumValue = self._createFunctionIsEnumValue(value)
       enum_values = []
       enum_tooltip = ''
@@ -455,7 +437,7 @@ class JsonGenerator:
       enum_values.sort()
       enum_data = {}
       enum_data[_KEY_ENUM_CLASS_NAME] = enum_class_name
-      enum_data[_KEY_MODULE_NAME] = getModuleName(value.__module__)
+      enum_data[_KEY_MODULE_NAME] = self._getModuleName(value)
       enum_data[_KEY_ENUM_VALUES] = enum_values
       if enum_tooltip is not None:
         enum_data[_KEY_TOOLTIP] = enum_tooltip
@@ -465,47 +447,32 @@ class JsonGenerator:
     class_data[_KEY_ENUMS] = sorted(enums, key=lambda enum_data: enum_data[_KEY_ENUM_CLASS_NAME])
     return class_data
 
-
   def _processClasses(self):
     class_data_list = []
-    set_of_classes = set()
     for cls in self._getPublicClasses():
-      for c in inspect.getmro(cls):
-        if python_util.isBuiltInClass(c):
-          break
-        set_of_classes.add(c)
-    for cls in set_of_classes:
       if python_util.isEnum(cls):
         continue
-      module_name = getModuleName(cls.__module__)
+      module_name = self._getModuleName(cls)
       if ignoreModule(module_name):
         continue
-      #module = python_util.getModule(module_name)
-      #if not hasattr(module, '__all__'):
-      #  print(f'Skipping class {getClassName(cls)} because module {module_name} has no __all__')
-      #  continue
-      #elif cls.__name__ not in module.__all__:
-      #  print(f'Skipping class {getClassName(cls)} because module {module_name}.__all__ does not include {cls.__name__}')
-      #  continue
       class_data = self._processClass(cls)
-      class_data_list.append(class_data)
+      if class_data:
+        class_data_list.append(class_data)
     return sorted(class_data_list, key=lambda class_data: class_data[_KEY_CLASS_NAME])
-
 
   def _processAliases(self):
     aliases = {}
-    for full_class_name, alias in self._dict_full_class_name_to_alias.items():
-      aliases[getClassName(full_class_name)] = getClassName(alias)
+    for full_class_name, alias in self._type_aliases.items():
+      aliases[self._getClassName(full_class_name)] = self._getClassName(alias)
     return aliases
-
 
   def _processSubclasses(self):
     subclasses = {}
-    for full_class_name, full_subclass_names in self._dict_full_class_name_to_subclass_names.items():
+    for full_class_name, full_subclass_names in self._subclasses.items():
       list = []
       for full_subclass_name in full_subclass_names:
-        list.append(getClassName(full_subclass_name))
-      subclasses[getClassName(full_class_name)] = list
+        list.append(self._getClassName(full_subclass_name))
+      subclasses[self._getClassName(full_class_name)] = list
     return subclasses
 
   def _getJsonData(self):
@@ -520,4 +487,5 @@ class JsonGenerator:
     json_data = self._getJsonData()
     json_file = open(file_path, 'w', encoding='utf-8')
     json.dump(json_data, json_file, sort_keys=True, indent=4)
+    json_file.write('\n')
     json_file.close()

--- a/server_python_scripts/blocks_base_classes/__init__.py
+++ b/server_python_scripts/blocks_base_classes/__init__.py
@@ -4,5 +4,13 @@ from .opmode import OpMode, Teleop, Auto, Test, Name, Group
 from .mechanism import Mechanism
 from .robot_base import RobotBase
 
-__all__ = ['OpMode', 'Teleop', 'Auto', 'Test', 'Name', 'Group'
-           'Mechanism', 'RobotBase']
+__all__ = [
+    'OpMode',
+    'Teleop',
+    'Auto',
+    'Test',
+    'Name',
+    'Group',
+    'Mechanism',
+    'RobotBase',
+]

--- a/server_python_scripts/expansion_hub.py
+++ b/server_python_scripts/expansion_hub.py
@@ -17,39 +17,39 @@ class ExpansionHubPidConstants:
         options = ntcore.PubSubOptions(sendAll=True, keepDuplicates=True, periodic=0.005)
 
         self.pPublisher = (systemServer
-            .getDoubleTopic("/rhsp/" + hubNumber + "/motor" + motorNumber + "/pid/" + pidType + "/kp")
+            .getDoubleTopic("/rhsp/" + str(hubNumber) + "/motor" + str(motorNumber) + "/pid/" + pidType + "/kp")
             .publish(options))
 
         self.iPublisher = (systemServer
-            .getDoubleTopic("/rhsp/" + hubNumber + "/motor" + motorNumber + "/pid/" + pidType + "/ki")
+            .getDoubleTopic("/rhsp/" + str(hubNumber) + "/motor" + str(motorNumber) + "/pid/" + pidType + "/ki")
             .publish(options))
 
         self.dPublisher = (systemServer
-            .getDoubleTopic("/rhsp/" + hubNumber + "/motor" + motorNumber + "/pid/" + pidType + "/kd")
+            .getDoubleTopic("/rhsp/" + str(hubNumber) + "/motor" + str(motorNumber) + "/pid/" + pidType + "/kd")
             .publish(options))
 
         self.aPublisher = (systemServer
-            .getDoubleTopic("/rhsp/" + hubNumber + "/motor" + motorNumber + "/pid/" + pidType + "/ka")
+            .getDoubleTopic("/rhsp/" + str(hubNumber) + "/motor" + str(motorNumber) + "/pid/" + pidType + "/ka")
             .publish(options))
 
         self.vPublisher = (systemServer
-            .getDoubleTopic("/rhsp/" + hubNumber + "/motor" + motorNumber + "/pid/" + pidType + "/kv")
+            .getDoubleTopic("/rhsp/" + str(hubNumber) + "/motor" + str(motorNumber) + "/pid/" + pidType + "/kv")
             .publish(options))
 
         self.sPublisher = (systemServer
-            .getDoubleTopic("/rhsp/" + hubNumber + "/motor" + motorNumber + "/pid/" + pidType + "/ks")
+            .getDoubleTopic("/rhsp/" + str(hubNumber) + "/motor" + str(motorNumber) + "/pid/" + pidType + "/ks")
             .publish(options))
 
         self.continuousPublisher = (systemServer
-            .getBooleanTopic("/rhsp/" + hubNumber + "/motor" + motorNumber + "/pid/" + pidType + "/continuous")
+            .getBooleanTopic("/rhsp/" + str(hubNumber) + "/motor" + str(motorNumber) + "/pid/" + pidType + "/continuous")
             .publish(options))
 
         self.continuousMinimumPublisher = (systemServer
-            .getDoubleTopic("/rhsp/" + hubNumber + "/motor" + motorNumber + "/pid/" + pidType + "/continuousMinimum")
+            .getDoubleTopic("/rhsp/" + str(hubNumber) + "/motor" + str(motorNumber) + "/pid/" + pidType + "/continuousMinimum")
             .publish(options))
 
         self.continuousMaximumPublisher = (systemServer
-            .getDoubleTopic("/rhsp/" + hubNumber + "/motor" + motorNumber + "/pid/" + pidType + "/continousMaximum")
+            .getDoubleTopic("/rhsp/" + str(hubNumber) + "/motor" + str(motorNumber) + "/pid/" + pidType + "/continousMaximum")
             .publish(options))
 
     def setPID(self, p: float, i: float, d: float):
@@ -83,45 +83,45 @@ class ExpansionHubMotor:
         options = ntcore.PubSubOptions(sendAll=True, keepDuplicates=True, periodic=0.005)
 
         self.encoderSubscriber = (systemServer
-            .getDoubleTopic("/rhsp/" + hubNumber + "/motor" + motorNumber + "/encoder")
+            .getDoubleTopic("/rhsp/" + str(hubNumber) + "/motor" + str(motorNumber) + "/encoder")
             .subscribe(0, options))
         self.encoderVelocitySubscriber = (systemServer
-            .getDoubleTopic("/rhsp/" + hubNumber + "/motor" +
-                motorNumber + "/encoderVelocity")
+            .getDoubleTopic("/rhsp/" + str(hubNumber) + "/motor" +
+                str(motorNumber) + "/encoderVelocity")
             .subscribe(0, options))
         self.currentSubscriber = (systemServer
-            .getDoubleTopic("/rhsp/" + hubNumber + "/motor" + motorNumber + "/current")
+            .getDoubleTopic("/rhsp/" + str(hubNumber) + "/motor" + str(motorNumber) + "/current")
             .subscribe(0, options))
 
-        self.hubConnectedSubscriber = systemServer.getBooleanTopic("/rhsp/" + hubNumber + "/connected").subscribe(False)
+        self.hubConnectedSubscriber = systemServer.getBooleanTopic("/rhsp/" + str(hubNumber) + "/connected").subscribe(False)
 
         self.setpointPublisher = (systemServer
-            .getDoubleTopic("/rhsp/" + hubNumber + "/motor" + motorNumber + "/setpoint")
+            .getDoubleTopic("/rhsp/" + str(hubNumber) + "/motor" + str(motorNumber) + "/setpoint")
             .publish(options))
 
         self.distancePerCountPublisher = (systemServer
-            .getDoubleTopic("/rhsp/" + hubNumber + "/motor" + motorNumber + "/distancePerCount")
+            .getDoubleTopic("/rhsp/" + str(hubNumber) + "/motor" + str(motorNumber) + "/distancePerCount")
             .publish(options))
 
         self.floatOn0Publisher = (systemServer
-            .getBooleanTopic("/rhsp/" + hubNumber + "/motor" +
-                motorNumber + "/floatOn0")
+            .getBooleanTopic("/rhsp/" + str(hubNumber) + "/motor" +
+                str(motorNumber) + "/floatOn0")
             .publish(options))
         self.enabledPublisher = (systemServer
-            .getBooleanTopic("/rhsp/" + hubNumber + "/motor" + motorNumber + "/enabled")
+            .getBooleanTopic("/rhsp/" + str(hubNumber) + "/motor" + str(motorNumber) + "/enabled")
             .publish(options))
 
         self.modePublisher = (systemServer
-            .getIntegerTopic("/rhsp/" + hubNumber + "/motor" + motorNumber + "/mode")
+            .getIntegerTopic("/rhsp/" + str(hubNumber) + "/motor" + str(motorNumber) + "/mode")
             .publish(options))
 
         self.reversedPublisher = (systemServer
-            .getBooleanTopic("/rhsp/" + hubNumber + "/motor" +
-                motorNumber + "/reversed")
+            .getBooleanTopic("/rhsp/" + str(hubNumber) + "/motor" +
+                str(motorNumber) + "/reversed")
             .publish(options))
 
         self.resetEncoderPublisher = (systemServer
-            .getBooleanTopic("/rhsp/" + hubNumber + "/motor" + motorNumber +
+            .getBooleanTopic("/rhsp/" + str(hubNumber) + "/motor" + str(motorNumber) +
                 "/resetEncoder")
             .publish(options))
 
@@ -189,22 +189,22 @@ class ExpansionHubServo:
 
         options = ntcore.PubSubOptions(sendAll=True, keepDuplicates=True, periodic=0.005)
 
-        self.hubConnectedSubscriber = systemServer.getBooleanTopic("/rhsp/" + hubNumber + "/connected").subscribe(False)
+        self.hubConnectedSubscriber = systemServer.getBooleanTopic("/rhsp/" + str(hubNumber) + "/connected").subscribe(False)
 
         self.pulseWidthPublisher = (systemServer
-            .getIntegerTopic("/rhsp/" + hubNumber + "/servo" + servoNumber + "/pulseWidth")
+            .getIntegerTopic("/rhsp/" + str(hubNumber) + "/servo" + str(servoNumber) + "/pulseWidth")
             .publish(options))
 
         self.pulseWidthPublisher.set(1500)
 
         self.framePeriodPublisher = (systemServer
-            .getIntegerTopic("/rhsp/" + hubNumber + "/servo" + servoNumber + "/framePeriod")
+            .getIntegerTopic("/rhsp/" + str(hubNumber) + "/servo" + str(servoNumber) + "/framePeriod")
             .publish(options))
 
         self.framePeriodPublisher.set(20000)
 
         self.enabledPublisher = (systemServer
-            .getBooleanTopic("/rhsp/" + hubNumber + "/servo" + servoNumber + "/enabled")
+            .getBooleanTopic("/rhsp/" + str(hubNumber) + "/servo" + str(servoNumber) + "/enabled")
             .publish(options))
 
     def set(self, value: float):
@@ -238,8 +238,8 @@ class ExpansionHub:
 
         self.hubNumber = hubNumber
 
-        self.batteryVoltageSubscriber = systemServer.getDoubleTopic("/rhsp/" + hubNumber + "/battery").subscribe(0)
-        self.connectedSubscriber = systemServer.getBooleanTopic("/rhsp/" + hubNumber + "/connected").subscribe(False)
+        self.batteryVoltageSubscriber = systemServer.getDoubleTopic("/rhsp/" + str(hubNumber) + "/battery").subscribe(0)
+        self.connectedSubscriber = systemServer.getBooleanTopic("/rhsp/" + str(hubNumber) + "/connected").subscribe(False)
 
     def isConnected(self) -> bool:
         return self.connectedSubscriber.get()

--- a/server_python_scripts/expansion_hub.py
+++ b/server_python_scripts/expansion_hub.py
@@ -1,0 +1,254 @@
+import ntcore
+import wpilib
+import wpimath.units
+
+class ExpansionHubPidConstants:
+    def __init__(self, hubNumber: int, motorNumber: int, isVelocityPid: bool):
+        if hubNumber < 0 or hubNumber > 3:
+            raise ValueError("hubNumber out of range")
+
+        if motorNumber < 0 or motorNumber > 3:
+            raise ValueError("motorNumber is out of range")
+
+        systemServer = wpilib.SystemServer.getSystemServer()
+
+        pidType =  "velocity" if isVelocityPid else "position"
+
+        options = ntcore.PubSubOptions(sendAll=True, keepDuplicates=True, periodic=0.005)
+
+        self.pPublisher = (systemServer
+            .getDoubleTopic("/rhsp/" + hubNumber + "/motor" + motorNumber + "/pid/" + pidType + "/kp")
+            .publish(options))
+
+        self.iPublisher = (systemServer
+            .getDoubleTopic("/rhsp/" + hubNumber + "/motor" + motorNumber + "/pid/" + pidType + "/ki")
+            .publish(options))
+
+        self.dPublisher = (systemServer
+            .getDoubleTopic("/rhsp/" + hubNumber + "/motor" + motorNumber + "/pid/" + pidType + "/kd")
+            .publish(options))
+
+        self.aPublisher = (systemServer
+            .getDoubleTopic("/rhsp/" + hubNumber + "/motor" + motorNumber + "/pid/" + pidType + "/ka")
+            .publish(options))
+
+        self.vPublisher = (systemServer
+            .getDoubleTopic("/rhsp/" + hubNumber + "/motor" + motorNumber + "/pid/" + pidType + "/kv")
+            .publish(options))
+
+        self.sPublisher = (systemServer
+            .getDoubleTopic("/rhsp/" + hubNumber + "/motor" + motorNumber + "/pid/" + pidType + "/ks")
+            .publish(options))
+
+        self.continuousPublisher = (systemServer
+            .getBooleanTopic("/rhsp/" + hubNumber + "/motor" + motorNumber + "/pid/" + pidType + "/continuous")
+            .publish(options))
+
+        self.continuousMinimumPublisher = (systemServer
+            .getDoubleTopic("/rhsp/" + hubNumber + "/motor" + motorNumber + "/pid/" + pidType + "/continuousMinimum")
+            .publish(options))
+
+        self.continuousMaximumPublisher = (systemServer
+            .getDoubleTopic("/rhsp/" + hubNumber + "/motor" + motorNumber + "/pid/" + pidType + "/continousMaximum")
+            .publish(options))
+
+    def setPID(self, p: float, i: float, d: float):
+        self.pPublisher.set(p)
+        self.iPublisher.set(i)
+        self.dPublisher.set(d)
+
+    def setFF(self, s: float, v: float, a: float):
+        self.sPublisher.set(s)
+        self.vPublisher.set(v)
+        self.aPublisher.set(a)
+
+    def enableContinousInput(self, minimum: float, maximum: float):
+        self.continuousMaximumPublisher.set(maximum)
+        self.continuousMinimumPublisher.set(minimum)
+        self.continuousPublisher.set(True)
+
+    def disableContinousInput(self):
+        self.continuousPublisher.set(False)
+
+class ExpansionHubMotor:
+    def __init__(self, hubNumber: int, motorNumber: int):
+        if hubNumber < 0 or hubNumber > 3:
+            raise ValueError("hubNumber out of range")
+
+        if motorNumber < 0 or motorNumber > 3:
+            raise ValueError("motorNumber is out of range")
+
+        systemServer = wpilib.SystemServer.getSystemServer()
+
+        options = ntcore.PubSubOptions(sendAll=True, keepDuplicates=True, periodic=0.005)
+
+        self.encoderSubscriber = (systemServer
+            .getDoubleTopic("/rhsp/" + hubNumber + "/motor" + motorNumber + "/encoder")
+            .subscribe(0, options))
+        self.encoderVelocitySubscriber = (systemServer
+            .getDoubleTopic("/rhsp/" + hubNumber + "/motor" +
+                motorNumber + "/encoderVelocity")
+            .subscribe(0, options))
+        self.currentSubscriber = (systemServer
+            .getDoubleTopic("/rhsp/" + hubNumber + "/motor" + motorNumber + "/current")
+            .subscribe(0, options))
+
+        self.hubConnectedSubscriber = systemServer.getBooleanTopic("/rhsp/" + hubNumber + "/connected").subscribe(False)
+
+        self.setpointPublisher = (systemServer
+            .getDoubleTopic("/rhsp/" + hubNumber + "/motor" + motorNumber + "/setpoint")
+            .publish(options))
+
+        self.distancePerCountPublisher = (systemServer
+            .getDoubleTopic("/rhsp/" + hubNumber + "/motor" + motorNumber + "/distancePerCount")
+            .publish(options))
+
+        self.floatOn0Publisher = (systemServer
+            .getBooleanTopic("/rhsp/" + hubNumber + "/motor" +
+                motorNumber + "/floatOn0")
+            .publish(options))
+        self.enabledPublisher = (systemServer
+            .getBooleanTopic("/rhsp/" + hubNumber + "/motor" + motorNumber + "/enabled")
+            .publish(options))
+
+        self.modePublisher = (systemServer
+            .getIntegerTopic("/rhsp/" + hubNumber + "/motor" + motorNumber + "/mode")
+            .publish(options))
+
+        self.reversedPublisher = (systemServer
+            .getBooleanTopic("/rhsp/" + hubNumber + "/motor" +
+                motorNumber + "/reversed")
+            .publish(options))
+
+        self.resetEncoderPublisher = (systemServer
+            .getBooleanTopic("/rhsp/" + hubNumber + "/motor" + motorNumber +
+                "/resetEncoder")
+            .publish(options))
+
+        self.velocityPidConstants = ExpansionHubPidConstants(hubNumber, motorNumber, True)
+        self.positionPidConstants = ExpansionHubPidConstants(hubNumber, motorNumber, False)
+
+    def setPercentagePower(self, power: float):
+        self.modePublisher.set(0)
+        self.setpointPublisher.set(power)
+
+    def setVoltage(self, voltage: wpimath.units.volts):
+        self.modePublisher.set(1)
+        self.setpointPublisher.set(voltage)
+
+    def setPositionSetpoint(self, setpoint: float):
+        self.modePublisher.set(2)
+        self.setpointPublisher.set(setpoint)
+
+    def setVelocitySetpoint(self, setpoint: float):
+        self.modePublisher.set(3)
+        self.setpointPublisher.set(setpoint)
+
+    def setEnabled(self, enabled: bool):
+        self.enabledPublisher.set(enabled)
+
+    def setFloatOn0(self, floatOn0: bool):
+        self.floatOn0Publisher.set(floatOn0)
+
+    def getCurrent(self) -> float:
+        return self.currentSubscriber.get()
+
+    def setDistancePerCount(self, perCount: float):
+        self.distancePerCountPublisher.set(perCount)
+
+    def isHubConnected(self) -> bool:
+        return self.hubConnectedSubscriber.get()
+
+    def getEncoder(self) -> float:
+        return self.encoderSubscriber.get()
+
+    def getEncoderVelocity(self) -> float:
+        return self.encoderVelocitySubscriber.get()
+
+    def setReversed(self, reversed: bool):
+        self.reversedPublisher.set(reversed)
+
+    def resetEncoder(self):
+        self.resetEncoderPublisher.set(True)
+
+    def getVelocityPidConstants(self) -> ExpansionHubPidConstants:
+        return self.velocityPidConstants
+
+    def getPositionPidConstants(self) -> ExpansionHubPidConstants:
+        return self.positionPidConstants
+
+class ExpansionHubServo:
+    def __init__(self, hubNumber: int, servoNumber: int):
+        if hubNumber < 0 or hubNumber > 3:
+            raise ValueError("hubNumber out of range")
+
+        if servoNumber < 0 or servoNumber > 5:
+            raise ValueError("servoNumber is out of range")
+
+        systemServer = wpilib.SystemServer.getSystemServer()
+
+        options = ntcore.PubSubOptions(sendAll=True, keepDuplicates=True, periodic=0.005)
+
+        self.hubConnectedSubscriber = systemServer.getBooleanTopic("/rhsp/" + hubNumber + "/connected").subscribe(False)
+
+        self.pulseWidthPublisher = (systemServer
+            .getIntegerTopic("/rhsp/" + hubNumber + "/servo" + servoNumber + "/pulseWidth")
+            .publish(options))
+
+        self.pulseWidthPublisher.set(1500)
+
+        self.framePeriodPublisher = (systemServer
+            .getIntegerTopic("/rhsp/" + hubNumber + "/servo" + servoNumber + "/framePeriod")
+            .publish(options))
+
+        self.framePeriodPublisher.set(20000)
+
+        self.enabledPublisher = (systemServer
+            .getBooleanTopic("/rhsp/" + hubNumber + "/servo" + servoNumber + "/enabled")
+            .publish(options))
+
+    def set(self, value: float):
+        value = max(1.0, min(0.0, value))
+        rawValue = (value * 1800) + 600
+
+        self.setPulseWidth(int(rawValue))
+
+    def setAngle(self, degrees: float):
+        degrees = max(180.0, min(0.0, degrees))
+        self.set(degrees / 180.0)
+
+    def setEnabled(self, enabled: bool):
+        self.enabledPublisher.set(enabled)
+
+    def isHubConnected(self) -> bool:
+        return self.hubConnectedSubscriber.get()
+
+    def setFramePeriod(self, framePeriod: int):
+        self.framePeriodPublisher.set(framePeriod)
+
+    def setPulseWidth(self, pulseWidth: int):
+        self.pulseWidthPublisher.set(pulseWidth)
+
+class ExpansionHub:
+    def __init__(self, hubNumber: int):
+        if hubNumber < 0 or hubNumber > 3:
+            raise ValueError("hubNumber out of range")
+
+        systemServer = wpilib.SystemServer.getSystemServer()
+
+        self.hubNumber = hubNumber
+
+        self.batteryVoltageSubscriber = systemServer.getDoubleTopic("/rhsp/" + hubNumber + "/battery").subscribe(0)
+        self.connectedSubscriber = systemServer.getBooleanTopic("/rhsp/" + hubNumber + "/connected").subscribe(False)
+
+    def isConnected(self) -> bool:
+        return self.connectedSubscriber.get()
+
+    def getBatteryVoltage(self) -> float:
+        return self.batteryVoltageSubscriber.get()
+
+    def getMotor(self, motorNumber: int) -> ExpansionHubMotor:
+        return ExpansionHubMotor(self.hubNumber, motorNumber)
+
+    def getServo(self, servoNumber: int) -> ExpansionHubServo:
+        return ExpansionHubServo(self.hubNumber, servoNumber)

--- a/src/blocks/utils/generated/external_samples_data.json
+++ b/src/blocks/utils/generated/external_samples_data.json
@@ -1105,7 +1105,7 @@
             ]
         },
         {
-            "className": "spark_mini.SparkMiniComponent",
+            "className": "spark_mini.SparkMini",
             "classVariables": [],
             "constructors": [
                 {
@@ -1116,9 +1116,9 @@
                             "type": "list[tuple[component.PortType, int]]"
                         }
                     ],
-                    "declaringClassName": "spark_mini.SparkMiniComponent",
+                    "declaringClassName": "spark_mini.SparkMini",
                     "functionName": "__init__",
-                    "returnType": "spark_mini.SparkMiniComponent",
+                    "returnType": "spark_mini.SparkMini",
                     "tooltip": ""
                 }
             ],
@@ -1129,7 +1129,7 @@
                         {
                             "defaultValue": "",
                             "name": "self",
-                            "type": "spark_mini.SparkMiniComponent"
+                            "type": "spark_mini.SparkMini"
                         },
                         {
                             "defaultValue": "",
@@ -1137,7 +1137,7 @@
                             "type": "wpilib.PWMMotorController"
                         }
                     ],
-                    "declaringClassName": "spark_mini.SparkMiniComponent",
+                    "declaringClassName": "spark_mini.SparkMini",
                     "functionName": "add_follower",
                     "returnType": "None",
                     "tooltip": "Make the given PWM motor controller follow the output of this one.\n\n:param follower: The motor controller follower."
@@ -1147,10 +1147,10 @@
                         {
                             "defaultValue": "",
                             "name": "self",
-                            "type": "spark_mini.SparkMiniComponent"
+                            "type": "spark_mini.SparkMini"
                         }
                     ],
-                    "declaringClassName": "spark_mini.SparkMiniComponent",
+                    "declaringClassName": "spark_mini.SparkMini",
                     "functionName": "check",
                     "returnType": "None",
                     "tooltip": "Check if this motor has exceeded its timeout.\n\nThis method is called periodically to determine if this motor has exceeded\nits timeout value. If it has, the stop method is called, and the motor is\nshut down until its value is updated again."
@@ -1160,10 +1160,10 @@
                         {
                             "defaultValue": "",
                             "name": "self",
-                            "type": "spark_mini.SparkMiniComponent"
+                            "type": "spark_mini.SparkMini"
                         }
                     ],
-                    "declaringClassName": "spark_mini.SparkMiniComponent",
+                    "declaringClassName": "spark_mini.SparkMini",
                     "functionName": "disable",
                     "returnType": "None",
                     "tooltip": ""
@@ -1173,7 +1173,7 @@
                         {
                             "defaultValue": "",
                             "name": "self",
-                            "type": "spark_mini.SparkMiniComponent"
+                            "type": "spark_mini.SparkMini"
                         },
                         {
                             "defaultValue": "",
@@ -1181,7 +1181,7 @@
                             "type": "bool"
                         }
                     ],
-                    "declaringClassName": "spark_mini.SparkMiniComponent",
+                    "declaringClassName": "spark_mini.SparkMini",
                     "functionName": "enable_deadband_elimination",
                     "returnType": "None",
                     "tooltip": "Optionally eliminate the deadband from a motor controller.\n\n:param eliminateDeadband: If true, set the motor curve on the motor\n                          controller to eliminate the deadband in the middle\n                          of the range. Otherwise, keep the full range\n                          without modifying any values."
@@ -1191,10 +1191,10 @@
                         {
                             "defaultValue": "",
                             "name": "self",
-                            "type": "spark_mini.SparkMiniComponent"
+                            "type": "spark_mini.SparkMini"
                         }
                     ],
-                    "declaringClassName": "spark_mini.SparkMiniComponent",
+                    "declaringClassName": "spark_mini.SparkMini",
                     "functionName": "feed",
                     "returnType": "None",
                     "tooltip": "Feed the motor safety object.\n\nResets the timer on this object that is used to do the timeouts."
@@ -1204,10 +1204,10 @@
                         {
                             "defaultValue": "",
                             "name": "self",
-                            "type": "spark_mini.SparkMiniComponent"
+                            "type": "spark_mini.SparkMini"
                         }
                     ],
-                    "declaringClassName": "spark_mini.SparkMiniComponent",
+                    "declaringClassName": "spark_mini.SparkMini",
                     "functionName": "get",
                     "returnType": "float",
                     "tooltip": "Get the recently set value of the PWM. This value is affected by the\ninversion property. If you want the value that is sent directly to the\nMotorController, use PWM::GetSpeed() instead.\n\n:returns: The most recently set value for the PWM between -1.0 and 1.0."
@@ -1217,10 +1217,10 @@
                         {
                             "defaultValue": "",
                             "name": "self",
-                            "type": "spark_mini.SparkMiniComponent"
+                            "type": "spark_mini.SparkMini"
                         }
                     ],
-                    "declaringClassName": "spark_mini.SparkMiniComponent",
+                    "declaringClassName": "spark_mini.SparkMini",
                     "functionName": "get_channel",
                     "returnType": "int",
                     "tooltip": ""
@@ -1230,10 +1230,10 @@
                         {
                             "defaultValue": "",
                             "name": "self",
-                            "type": "spark_mini.SparkMiniComponent"
+                            "type": "spark_mini.SparkMini"
                         }
                     ],
-                    "declaringClassName": "spark_mini.SparkMiniComponent",
+                    "declaringClassName": "spark_mini.SparkMini",
                     "functionName": "get_connection_port_type",
                     "returnType": "list[component.PortType]",
                     "tooltip": ""
@@ -1243,10 +1243,10 @@
                         {
                             "defaultValue": "",
                             "name": "self",
-                            "type": "spark_mini.SparkMiniComponent"
+                            "type": "spark_mini.SparkMini"
                         }
                     ],
-                    "declaringClassName": "spark_mini.SparkMiniComponent",
+                    "declaringClassName": "spark_mini.SparkMini",
                     "functionName": "get_description",
                     "returnType": "str",
                     "tooltip": ""
@@ -1256,10 +1256,10 @@
                         {
                             "defaultValue": "",
                             "name": "self",
-                            "type": "spark_mini.SparkMiniComponent"
+                            "type": "spark_mini.SparkMini"
                         }
                     ],
-                    "declaringClassName": "spark_mini.SparkMiniComponent",
+                    "declaringClassName": "spark_mini.SparkMini",
                     "functionName": "get_expiration",
                     "returnType": "float",
                     "tooltip": "Retrieve the timeout value for the corresponding motor safety object.\n\n:returns: the timeout value."
@@ -1269,10 +1269,10 @@
                         {
                             "defaultValue": "",
                             "name": "self",
-                            "type": "spark_mini.SparkMiniComponent"
+                            "type": "spark_mini.SparkMini"
                         }
                     ],
-                    "declaringClassName": "spark_mini.SparkMiniComponent",
+                    "declaringClassName": "spark_mini.SparkMini",
                     "functionName": "get_inverted",
                     "returnType": "bool",
                     "tooltip": ""
@@ -1282,10 +1282,10 @@
                         {
                             "defaultValue": "",
                             "name": "self",
-                            "type": "spark_mini.SparkMiniComponent"
+                            "type": "spark_mini.SparkMini"
                         }
                     ],
-                    "declaringClassName": "spark_mini.SparkMiniComponent",
+                    "declaringClassName": "spark_mini.SparkMini",
                     "functionName": "get_manufacturer",
                     "returnType": "str",
                     "tooltip": ""
@@ -1295,10 +1295,10 @@
                         {
                             "defaultValue": "",
                             "name": "self",
-                            "type": "spark_mini.SparkMiniComponent"
+                            "type": "spark_mini.SparkMini"
                         }
                     ],
-                    "declaringClassName": "spark_mini.SparkMiniComponent",
+                    "declaringClassName": "spark_mini.SparkMini",
                     "functionName": "get_name",
                     "returnType": "str",
                     "tooltip": ""
@@ -1308,10 +1308,10 @@
                         {
                             "defaultValue": "",
                             "name": "self",
-                            "type": "spark_mini.SparkMiniComponent"
+                            "type": "spark_mini.SparkMini"
                         }
                     ],
-                    "declaringClassName": "spark_mini.SparkMiniComponent",
+                    "declaringClassName": "spark_mini.SparkMini",
                     "functionName": "get_part_number",
                     "returnType": "str",
                     "tooltip": ""
@@ -1321,10 +1321,10 @@
                         {
                             "defaultValue": "",
                             "name": "self",
-                            "type": "spark_mini.SparkMiniComponent"
+                            "type": "spark_mini.SparkMini"
                         }
                     ],
-                    "declaringClassName": "spark_mini.SparkMiniComponent",
+                    "declaringClassName": "spark_mini.SparkMini",
                     "functionName": "get_url",
                     "returnType": "str",
                     "tooltip": ""
@@ -1334,10 +1334,10 @@
                         {
                             "defaultValue": "",
                             "name": "self",
-                            "type": "spark_mini.SparkMiniComponent"
+                            "type": "spark_mini.SparkMini"
                         }
                     ],
-                    "declaringClassName": "spark_mini.SparkMiniComponent",
+                    "declaringClassName": "spark_mini.SparkMini",
                     "functionName": "get_version",
                     "returnType": "tuple[int, int, int]",
                     "tooltip": ""
@@ -1347,10 +1347,10 @@
                         {
                             "defaultValue": "",
                             "name": "self",
-                            "type": "spark_mini.SparkMiniComponent"
+                            "type": "spark_mini.SparkMini"
                         }
                     ],
-                    "declaringClassName": "spark_mini.SparkMiniComponent",
+                    "declaringClassName": "spark_mini.SparkMini",
                     "functionName": "get_voltage",
                     "returnType": "float",
                     "tooltip": "Gets the voltage output of the motor controller, nominally between -12 V\nand 12 V.\n\n:returns: The voltage of the motor controller, nominally between -12 V and 12\n          V."
@@ -1360,7 +1360,7 @@
                         {
                             "defaultValue": "",
                             "name": "self",
-                            "type": "spark_mini.SparkMiniComponent"
+                            "type": "spark_mini.SparkMini"
                         },
                         {
                             "defaultValue": "",
@@ -1368,7 +1368,7 @@
                             "type": "wpiutil.SendableBuilder"
                         }
                     ],
-                    "declaringClassName": "spark_mini.SparkMiniComponent",
+                    "declaringClassName": "spark_mini.SparkMini",
                     "functionName": "init_sendable",
                     "returnType": "None",
                     "tooltip": "Initializes this Sendable object.\n\n:param builder: sendable builder"
@@ -1378,10 +1378,10 @@
                         {
                             "defaultValue": "",
                             "name": "self",
-                            "type": "spark_mini.SparkMiniComponent"
+                            "type": "spark_mini.SparkMini"
                         }
                     ],
-                    "declaringClassName": "spark_mini.SparkMiniComponent",
+                    "declaringClassName": "spark_mini.SparkMini",
                     "functionName": "is_alive",
                     "returnType": "bool",
                     "tooltip": "Determine if the motor is still operating or has timed out.\n\n:returns: true if the motor is still operating normally and hasn't timed out."
@@ -1391,10 +1391,10 @@
                         {
                             "defaultValue": "",
                             "name": "self",
-                            "type": "spark_mini.SparkMiniComponent"
+                            "type": "spark_mini.SparkMini"
                         }
                     ],
-                    "declaringClassName": "spark_mini.SparkMiniComponent",
+                    "declaringClassName": "spark_mini.SparkMini",
                     "functionName": "is_safety_enabled",
                     "returnType": "bool",
                     "tooltip": "Return the state of the motor safety enabled flag.\n\nReturn if the motor safety is currently enabled for this device.\n\n:returns: True if motor safety is enforced for this device."
@@ -1404,10 +1404,10 @@
                         {
                             "defaultValue": "",
                             "name": "self",
-                            "type": "spark_mini.SparkMiniComponent"
+                            "type": "spark_mini.SparkMini"
                         }
                     ],
-                    "declaringClassName": "spark_mini.SparkMiniComponent",
+                    "declaringClassName": "spark_mini.SparkMini",
                     "functionName": "periodic",
                     "returnType": "None",
                     "tooltip": ""
@@ -1417,10 +1417,10 @@
                         {
                             "defaultValue": "",
                             "name": "self",
-                            "type": "spark_mini.SparkMiniComponent"
+                            "type": "spark_mini.SparkMini"
                         }
                     ],
-                    "declaringClassName": "spark_mini.SparkMiniComponent",
+                    "declaringClassName": "spark_mini.SparkMini",
                     "functionName": "reset",
                     "returnType": "None",
                     "tooltip": ""
@@ -1430,7 +1430,7 @@
                         {
                             "defaultValue": "",
                             "name": "self",
-                            "type": "spark_mini.SparkMiniComponent"
+                            "type": "spark_mini.SparkMini"
                         },
                         {
                             "defaultValue": "",
@@ -1438,7 +1438,7 @@
                             "type": "float"
                         }
                     ],
-                    "declaringClassName": "spark_mini.SparkMiniComponent",
+                    "declaringClassName": "spark_mini.SparkMini",
                     "functionName": "set",
                     "returnType": "None",
                     "tooltip": "Set the PWM value.\n\nThe PWM value is set using a range of -1.0 to 1.0, appropriately scaling\nthe value for the FPGA.\n\n:param value: The speed value between -1.0 and 1.0 to set."
@@ -1448,7 +1448,7 @@
                         {
                             "defaultValue": "",
                             "name": "self",
-                            "type": "spark_mini.SparkMiniComponent"
+                            "type": "spark_mini.SparkMini"
                         },
                         {
                             "defaultValue": "",
@@ -1456,7 +1456,7 @@
                             "type": "float"
                         }
                     ],
-                    "declaringClassName": "spark_mini.SparkMiniComponent",
+                    "declaringClassName": "spark_mini.SparkMini",
                     "functionName": "set_expiration",
                     "returnType": "None",
                     "tooltip": "Set the expiration time for the corresponding motor safety object.\n\n:param expirationTime: The timeout value."
@@ -1466,7 +1466,7 @@
                         {
                             "defaultValue": "",
                             "name": "self",
-                            "type": "spark_mini.SparkMiniComponent"
+                            "type": "spark_mini.SparkMini"
                         },
                         {
                             "defaultValue": "",
@@ -1474,7 +1474,7 @@
                             "type": "bool"
                         }
                     ],
-                    "declaringClassName": "spark_mini.SparkMiniComponent",
+                    "declaringClassName": "spark_mini.SparkMini",
                     "functionName": "set_inverted",
                     "returnType": "None",
                     "tooltip": ""
@@ -1484,7 +1484,7 @@
                         {
                             "defaultValue": "",
                             "name": "self",
-                            "type": "spark_mini.SparkMiniComponent"
+                            "type": "spark_mini.SparkMini"
                         },
                         {
                             "defaultValue": "",
@@ -1492,7 +1492,7 @@
                             "type": "bool"
                         }
                     ],
-                    "declaringClassName": "spark_mini.SparkMiniComponent",
+                    "declaringClassName": "spark_mini.SparkMini",
                     "functionName": "set_safety_enabled",
                     "returnType": "None",
                     "tooltip": "Enable/disable motor safety for this device.\n\nTurn on and off the motor safety option for this PWM object.\n\n:param enabled: True if motor safety is enforced for this object."
@@ -1502,7 +1502,7 @@
                         {
                             "defaultValue": "",
                             "name": "self",
-                            "type": "spark_mini.SparkMiniComponent"
+                            "type": "spark_mini.SparkMini"
                         },
                         {
                             "defaultValue": "",
@@ -1510,7 +1510,7 @@
                             "type": "float"
                         }
                     ],
-                    "declaringClassName": "spark_mini.SparkMiniComponent",
+                    "declaringClassName": "spark_mini.SparkMini",
                     "functionName": "set_voltage",
                     "returnType": "None",
                     "tooltip": "Sets the voltage output of the PWMMotorController. Compensates for\nthe current bus voltage to ensure that the desired voltage is output even\nif the battery voltage is below 12V - highly useful when the voltage\noutputs are \"meaningful\" (e.g. they come from a feedforward calculation).\n\nNOTE: This function *must* be called regularly in order for voltage\ncompensation to work properly - unlike the ordinary set function, it is not\n\"set it and forget it.\"\n\n:param output: The voltage to output."
@@ -1520,10 +1520,10 @@
                         {
                             "defaultValue": "",
                             "name": "self",
-                            "type": "spark_mini.SparkMiniComponent"
+                            "type": "spark_mini.SparkMini"
                         }
                     ],
-                    "declaringClassName": "spark_mini.SparkMiniComponent",
+                    "declaringClassName": "spark_mini.SparkMini",
                     "functionName": "stop",
                     "returnType": "None",
                     "tooltip": ""
@@ -1533,10 +1533,10 @@
                         {
                             "defaultValue": "",
                             "name": "self",
-                            "type": "spark_mini.SparkMiniComponent"
+                            "type": "spark_mini.SparkMini"
                         }
                     ],
-                    "declaringClassName": "spark_mini.SparkMiniComponent",
+                    "declaringClassName": "spark_mini.SparkMini",
                     "functionName": "stop_motor",
                     "returnType": "None",
                     "tooltip": ""
@@ -1547,7 +1547,7 @@
             "staticMethods": [
                 {
                     "args": [],
-                    "declaringClassName": "spark_mini.SparkMiniComponent",
+                    "declaringClassName": "spark_mini.SparkMini",
                     "functionName": "check_motors",
                     "returnType": "None",
                     "tooltip": "Check the motors to see if any have timed out.\n\nThis static method is called periodically to poll all the motors and stop\nany that have timed out."
@@ -1560,9 +1560,9 @@
                             "type": "int"
                         }
                     ],
-                    "declaringClassName": "spark_mini.SparkMiniComponent",
+                    "declaringClassName": "spark_mini.SparkMini",
                     "functionName": "from_smart_motor_port",
-                    "returnType": "spark_mini.SparkMiniComponent",
+                    "returnType": "spark_mini.SparkMini",
                     "tooltip": ""
                 }
             ]
@@ -1855,7 +1855,7 @@
             "rev_touch_sensor.RevTouchSensor",
             "servo.Servo",
             "smart_motor.SmartMotor",
-            "spark_mini.SparkMiniComponent",
+            "spark_mini.SparkMini",
             "sparkfun_led_stick.SparkFunLEDStick"
         ]
     }

--- a/src/blocks/utils/generated/robotpy_data.json
+++ b/src/blocks/utils/generated/robotpy_data.json
@@ -304,6 +304,618 @@
     },
     "classes": [
         {
+            "className": "expansion_hub.ExpansionHub",
+            "classVariables": [],
+            "constructors": [
+                {
+                    "args": [
+                        {
+                            "defaultValue": "",
+                            "name": "hubNumber",
+                            "type": "int"
+                        }
+                    ],
+                    "declaringClassName": "expansion_hub.ExpansionHub",
+                    "functionName": "__init__",
+                    "returnType": "expansion_hub.ExpansionHub",
+                    "tooltip": ""
+                }
+            ],
+            "enums": [],
+            "instanceMethods": [
+                {
+                    "args": [
+                        {
+                            "defaultValue": "",
+                            "name": "self",
+                            "type": "expansion_hub.ExpansionHub"
+                        }
+                    ],
+                    "declaringClassName": "expansion_hub.ExpansionHub",
+                    "functionName": "getBatteryVoltage",
+                    "returnType": "float",
+                    "tooltip": ""
+                },
+                {
+                    "args": [
+                        {
+                            "defaultValue": "",
+                            "name": "self",
+                            "type": "expansion_hub.ExpansionHub"
+                        },
+                        {
+                            "defaultValue": "",
+                            "name": "motorNumber",
+                            "type": "int"
+                        }
+                    ],
+                    "declaringClassName": "expansion_hub.ExpansionHub",
+                    "functionName": "getMotor",
+                    "returnType": "expansion_hub.ExpansionHubMotor",
+                    "tooltip": ""
+                },
+                {
+                    "args": [
+                        {
+                            "defaultValue": "",
+                            "name": "self",
+                            "type": "expansion_hub.ExpansionHub"
+                        },
+                        {
+                            "defaultValue": "",
+                            "name": "servoNumber",
+                            "type": "int"
+                        }
+                    ],
+                    "declaringClassName": "expansion_hub.ExpansionHub",
+                    "functionName": "getServo",
+                    "returnType": "expansion_hub.ExpansionHubServo",
+                    "tooltip": ""
+                },
+                {
+                    "args": [
+                        {
+                            "defaultValue": "",
+                            "name": "self",
+                            "type": "expansion_hub.ExpansionHub"
+                        }
+                    ],
+                    "declaringClassName": "expansion_hub.ExpansionHub",
+                    "functionName": "isConnected",
+                    "returnType": "bool",
+                    "tooltip": ""
+                }
+            ],
+            "instanceVariables": [],
+            "moduleName": "expansion_hub",
+            "staticMethods": []
+        },
+        {
+            "className": "expansion_hub.ExpansionHubMotor",
+            "classVariables": [],
+            "constructors": [
+                {
+                    "args": [
+                        {
+                            "defaultValue": "",
+                            "name": "hubNumber",
+                            "type": "int"
+                        },
+                        {
+                            "defaultValue": "",
+                            "name": "motorNumber",
+                            "type": "int"
+                        }
+                    ],
+                    "declaringClassName": "expansion_hub.ExpansionHubMotor",
+                    "functionName": "__init__",
+                    "returnType": "expansion_hub.ExpansionHubMotor",
+                    "tooltip": ""
+                }
+            ],
+            "enums": [],
+            "instanceMethods": [
+                {
+                    "args": [
+                        {
+                            "defaultValue": "",
+                            "name": "self",
+                            "type": "expansion_hub.ExpansionHubMotor"
+                        }
+                    ],
+                    "declaringClassName": "expansion_hub.ExpansionHubMotor",
+                    "functionName": "getCurrent",
+                    "returnType": "float",
+                    "tooltip": ""
+                },
+                {
+                    "args": [
+                        {
+                            "defaultValue": "",
+                            "name": "self",
+                            "type": "expansion_hub.ExpansionHubMotor"
+                        }
+                    ],
+                    "declaringClassName": "expansion_hub.ExpansionHubMotor",
+                    "functionName": "getEncoder",
+                    "returnType": "float",
+                    "tooltip": ""
+                },
+                {
+                    "args": [
+                        {
+                            "defaultValue": "",
+                            "name": "self",
+                            "type": "expansion_hub.ExpansionHubMotor"
+                        }
+                    ],
+                    "declaringClassName": "expansion_hub.ExpansionHubMotor",
+                    "functionName": "getEncoderVelocity",
+                    "returnType": "float",
+                    "tooltip": ""
+                },
+                {
+                    "args": [
+                        {
+                            "defaultValue": "",
+                            "name": "self",
+                            "type": "expansion_hub.ExpansionHubMotor"
+                        }
+                    ],
+                    "declaringClassName": "expansion_hub.ExpansionHubMotor",
+                    "functionName": "getPositionPidConstants",
+                    "returnType": "expansion_hub.ExpansionHubPidConstants",
+                    "tooltip": ""
+                },
+                {
+                    "args": [
+                        {
+                            "defaultValue": "",
+                            "name": "self",
+                            "type": "expansion_hub.ExpansionHubMotor"
+                        }
+                    ],
+                    "declaringClassName": "expansion_hub.ExpansionHubMotor",
+                    "functionName": "getVelocityPidConstants",
+                    "returnType": "expansion_hub.ExpansionHubPidConstants",
+                    "tooltip": ""
+                },
+                {
+                    "args": [
+                        {
+                            "defaultValue": "",
+                            "name": "self",
+                            "type": "expansion_hub.ExpansionHubMotor"
+                        }
+                    ],
+                    "declaringClassName": "expansion_hub.ExpansionHubMotor",
+                    "functionName": "isHubConnected",
+                    "returnType": "bool",
+                    "tooltip": ""
+                },
+                {
+                    "args": [
+                        {
+                            "defaultValue": "",
+                            "name": "self",
+                            "type": "expansion_hub.ExpansionHubMotor"
+                        }
+                    ],
+                    "declaringClassName": "expansion_hub.ExpansionHubMotor",
+                    "functionName": "resetEncoder",
+                    "returnType": "None",
+                    "tooltip": ""
+                },
+                {
+                    "args": [
+                        {
+                            "defaultValue": "",
+                            "name": "self",
+                            "type": "expansion_hub.ExpansionHubMotor"
+                        },
+                        {
+                            "defaultValue": "",
+                            "name": "perCount",
+                            "type": "float"
+                        }
+                    ],
+                    "declaringClassName": "expansion_hub.ExpansionHubMotor",
+                    "functionName": "setDistancePerCount",
+                    "returnType": "None",
+                    "tooltip": ""
+                },
+                {
+                    "args": [
+                        {
+                            "defaultValue": "",
+                            "name": "self",
+                            "type": "expansion_hub.ExpansionHubMotor"
+                        },
+                        {
+                            "defaultValue": "",
+                            "name": "enabled",
+                            "type": "bool"
+                        }
+                    ],
+                    "declaringClassName": "expansion_hub.ExpansionHubMotor",
+                    "functionName": "setEnabled",
+                    "returnType": "None",
+                    "tooltip": ""
+                },
+                {
+                    "args": [
+                        {
+                            "defaultValue": "",
+                            "name": "self",
+                            "type": "expansion_hub.ExpansionHubMotor"
+                        },
+                        {
+                            "defaultValue": "",
+                            "name": "floatOn0",
+                            "type": "bool"
+                        }
+                    ],
+                    "declaringClassName": "expansion_hub.ExpansionHubMotor",
+                    "functionName": "setFloatOn0",
+                    "returnType": "None",
+                    "tooltip": ""
+                },
+                {
+                    "args": [
+                        {
+                            "defaultValue": "",
+                            "name": "self",
+                            "type": "expansion_hub.ExpansionHubMotor"
+                        },
+                        {
+                            "defaultValue": "",
+                            "name": "power",
+                            "type": "float"
+                        }
+                    ],
+                    "declaringClassName": "expansion_hub.ExpansionHubMotor",
+                    "functionName": "setPercentagePower",
+                    "returnType": "None",
+                    "tooltip": ""
+                },
+                {
+                    "args": [
+                        {
+                            "defaultValue": "",
+                            "name": "self",
+                            "type": "expansion_hub.ExpansionHubMotor"
+                        },
+                        {
+                            "defaultValue": "",
+                            "name": "setpoint",
+                            "type": "float"
+                        }
+                    ],
+                    "declaringClassName": "expansion_hub.ExpansionHubMotor",
+                    "functionName": "setPositionSetpoint",
+                    "returnType": "None",
+                    "tooltip": ""
+                },
+                {
+                    "args": [
+                        {
+                            "defaultValue": "",
+                            "name": "self",
+                            "type": "expansion_hub.ExpansionHubMotor"
+                        },
+                        {
+                            "defaultValue": "",
+                            "name": "reversed",
+                            "type": "bool"
+                        }
+                    ],
+                    "declaringClassName": "expansion_hub.ExpansionHubMotor",
+                    "functionName": "setReversed",
+                    "returnType": "None",
+                    "tooltip": ""
+                },
+                {
+                    "args": [
+                        {
+                            "defaultValue": "",
+                            "name": "self",
+                            "type": "expansion_hub.ExpansionHubMotor"
+                        },
+                        {
+                            "defaultValue": "",
+                            "name": "setpoint",
+                            "type": "float"
+                        }
+                    ],
+                    "declaringClassName": "expansion_hub.ExpansionHubMotor",
+                    "functionName": "setVelocitySetpoint",
+                    "returnType": "None",
+                    "tooltip": ""
+                },
+                {
+                    "args": [
+                        {
+                            "defaultValue": "",
+                            "name": "self",
+                            "type": "expansion_hub.ExpansionHubMotor"
+                        },
+                        {
+                            "defaultValue": "",
+                            "name": "voltage",
+                            "type": "float"
+                        }
+                    ],
+                    "declaringClassName": "expansion_hub.ExpansionHubMotor",
+                    "functionName": "setVoltage",
+                    "returnType": "None",
+                    "tooltip": ""
+                }
+            ],
+            "instanceVariables": [],
+            "moduleName": "expansion_hub",
+            "staticMethods": []
+        },
+        {
+            "className": "expansion_hub.ExpansionHubPidConstants",
+            "classVariables": [],
+            "constructors": [
+                {
+                    "args": [
+                        {
+                            "defaultValue": "",
+                            "name": "hubNumber",
+                            "type": "int"
+                        },
+                        {
+                            "defaultValue": "",
+                            "name": "motorNumber",
+                            "type": "int"
+                        },
+                        {
+                            "defaultValue": "",
+                            "name": "isVelocityPid",
+                            "type": "bool"
+                        }
+                    ],
+                    "declaringClassName": "expansion_hub.ExpansionHubPidConstants",
+                    "functionName": "__init__",
+                    "returnType": "expansion_hub.ExpansionHubPidConstants",
+                    "tooltip": ""
+                }
+            ],
+            "enums": [],
+            "instanceMethods": [
+                {
+                    "args": [
+                        {
+                            "defaultValue": "",
+                            "name": "self",
+                            "type": "expansion_hub.ExpansionHubPidConstants"
+                        }
+                    ],
+                    "declaringClassName": "expansion_hub.ExpansionHubPidConstants",
+                    "functionName": "disableContinousInput",
+                    "returnType": "None",
+                    "tooltip": ""
+                },
+                {
+                    "args": [
+                        {
+                            "defaultValue": "",
+                            "name": "self",
+                            "type": "expansion_hub.ExpansionHubPidConstants"
+                        },
+                        {
+                            "defaultValue": "",
+                            "name": "minimum",
+                            "type": "float"
+                        },
+                        {
+                            "defaultValue": "",
+                            "name": "maximum",
+                            "type": "float"
+                        }
+                    ],
+                    "declaringClassName": "expansion_hub.ExpansionHubPidConstants",
+                    "functionName": "enableContinousInput",
+                    "returnType": "None",
+                    "tooltip": ""
+                },
+                {
+                    "args": [
+                        {
+                            "defaultValue": "",
+                            "name": "self",
+                            "type": "expansion_hub.ExpansionHubPidConstants"
+                        },
+                        {
+                            "defaultValue": "",
+                            "name": "s",
+                            "type": "float"
+                        },
+                        {
+                            "defaultValue": "",
+                            "name": "v",
+                            "type": "float"
+                        },
+                        {
+                            "defaultValue": "",
+                            "name": "a",
+                            "type": "float"
+                        }
+                    ],
+                    "declaringClassName": "expansion_hub.ExpansionHubPidConstants",
+                    "functionName": "setFF",
+                    "returnType": "None",
+                    "tooltip": ""
+                },
+                {
+                    "args": [
+                        {
+                            "defaultValue": "",
+                            "name": "self",
+                            "type": "expansion_hub.ExpansionHubPidConstants"
+                        },
+                        {
+                            "defaultValue": "",
+                            "name": "p",
+                            "type": "float"
+                        },
+                        {
+                            "defaultValue": "",
+                            "name": "i",
+                            "type": "float"
+                        },
+                        {
+                            "defaultValue": "",
+                            "name": "d",
+                            "type": "float"
+                        }
+                    ],
+                    "declaringClassName": "expansion_hub.ExpansionHubPidConstants",
+                    "functionName": "setPID",
+                    "returnType": "None",
+                    "tooltip": ""
+                }
+            ],
+            "instanceVariables": [],
+            "moduleName": "expansion_hub",
+            "staticMethods": []
+        },
+        {
+            "className": "expansion_hub.ExpansionHubServo",
+            "classVariables": [],
+            "constructors": [
+                {
+                    "args": [
+                        {
+                            "defaultValue": "",
+                            "name": "hubNumber",
+                            "type": "int"
+                        },
+                        {
+                            "defaultValue": "",
+                            "name": "servoNumber",
+                            "type": "int"
+                        }
+                    ],
+                    "declaringClassName": "expansion_hub.ExpansionHubServo",
+                    "functionName": "__init__",
+                    "returnType": "expansion_hub.ExpansionHubServo",
+                    "tooltip": ""
+                }
+            ],
+            "enums": [],
+            "instanceMethods": [
+                {
+                    "args": [
+                        {
+                            "defaultValue": "",
+                            "name": "self",
+                            "type": "expansion_hub.ExpansionHubServo"
+                        }
+                    ],
+                    "declaringClassName": "expansion_hub.ExpansionHubServo",
+                    "functionName": "isHubConnected",
+                    "returnType": "bool",
+                    "tooltip": ""
+                },
+                {
+                    "args": [
+                        {
+                            "defaultValue": "",
+                            "name": "self",
+                            "type": "expansion_hub.ExpansionHubServo"
+                        },
+                        {
+                            "defaultValue": "",
+                            "name": "value",
+                            "type": "float"
+                        }
+                    ],
+                    "declaringClassName": "expansion_hub.ExpansionHubServo",
+                    "functionName": "set",
+                    "returnType": "None",
+                    "tooltip": ""
+                },
+                {
+                    "args": [
+                        {
+                            "defaultValue": "",
+                            "name": "self",
+                            "type": "expansion_hub.ExpansionHubServo"
+                        },
+                        {
+                            "defaultValue": "",
+                            "name": "degrees",
+                            "type": "float"
+                        }
+                    ],
+                    "declaringClassName": "expansion_hub.ExpansionHubServo",
+                    "functionName": "setAngle",
+                    "returnType": "None",
+                    "tooltip": ""
+                },
+                {
+                    "args": [
+                        {
+                            "defaultValue": "",
+                            "name": "self",
+                            "type": "expansion_hub.ExpansionHubServo"
+                        },
+                        {
+                            "defaultValue": "",
+                            "name": "enabled",
+                            "type": "bool"
+                        }
+                    ],
+                    "declaringClassName": "expansion_hub.ExpansionHubServo",
+                    "functionName": "setEnabled",
+                    "returnType": "None",
+                    "tooltip": ""
+                },
+                {
+                    "args": [
+                        {
+                            "defaultValue": "",
+                            "name": "self",
+                            "type": "expansion_hub.ExpansionHubServo"
+                        },
+                        {
+                            "defaultValue": "",
+                            "name": "framePeriod",
+                            "type": "int"
+                        }
+                    ],
+                    "declaringClassName": "expansion_hub.ExpansionHubServo",
+                    "functionName": "setFramePeriod",
+                    "returnType": "None",
+                    "tooltip": ""
+                },
+                {
+                    "args": [
+                        {
+                            "defaultValue": "",
+                            "name": "self",
+                            "type": "expansion_hub.ExpansionHubServo"
+                        },
+                        {
+                            "defaultValue": "",
+                            "name": "pulseWidth",
+                            "type": "int"
+                        }
+                    ],
+                    "declaringClassName": "expansion_hub.ExpansionHubServo",
+                    "functionName": "setPulseWidth",
+                    "returnType": "None",
+                    "tooltip": ""
+                }
+            ],
+            "instanceVariables": [],
+            "moduleName": "expansion_hub",
+            "staticMethods": []
+        },
+        {
             "className": "wpilib.ADXL345_I2C",
             "classVariables": [
                 {
@@ -2062,13 +2674,13 @@
                 {
                     "name": "kTeamDeviceType",
                     "tooltip": "",
-                    "type": "hal.CANDeviceType",
+                    "type": "hal._wpiHal.CANDeviceType",
                     "writable": false
                 },
                 {
                     "name": "kTeamManufacturer",
                     "tooltip": "",
-                    "type": "hal.CANManufacturer",
+                    "type": "hal._wpiHal.CANManufacturer",
                     "writable": false
                 }
             ],
@@ -2137,7 +2749,7 @@
                         {
                             "defaultValue": "",
                             "name": "data",
-                            "type": "hal.CANReceiveMessage"
+                            "type": "hal._wpiHal.CANReceiveMessage"
                         }
                     ],
                     "declaringClassName": "wpilib.CAN",
@@ -2160,7 +2772,7 @@
                         {
                             "defaultValue": "",
                             "name": "data",
-                            "type": "hal.CANReceiveMessage"
+                            "type": "hal._wpiHal.CANReceiveMessage"
                         }
                     ],
                     "declaringClassName": "wpilib.CAN",
@@ -2188,7 +2800,7 @@
                         {
                             "defaultValue": "",
                             "name": "data",
-                            "type": "hal.CANReceiveMessage"
+                            "type": "hal._wpiHal.CANReceiveMessage"
                         }
                     ],
                     "declaringClassName": "wpilib.CAN",
@@ -2229,7 +2841,7 @@
                         {
                             "defaultValue": "",
                             "name": "message",
-                            "type": "hal.CANMessage"
+                            "type": "hal._wpiHal.CANMessage"
                         }
                     ],
                     "declaringClassName": "wpilib.CAN",
@@ -2252,7 +2864,7 @@
                         {
                             "defaultValue": "",
                             "name": "message",
-                            "type": "hal.CANMessage"
+                            "type": "hal._wpiHal.CANMessage"
                         }
                     ],
                     "declaringClassName": "wpilib.CAN",
@@ -2275,7 +2887,7 @@
                         {
                             "defaultValue": "",
                             "name": "message",
-                            "type": "hal.CANMessage"
+                            "type": "hal._wpiHal.CANMessage"
                         },
                         {
                             "defaultValue": "",
@@ -2303,7 +2915,7 @@
                         {
                             "defaultValue": "",
                             "name": "message",
-                            "type": "hal.CANMessage"
+                            "type": "hal._wpiHal.CANMessage"
                         },
                         {
                             "defaultValue": "",
@@ -2331,7 +2943,7 @@
                         {
                             "defaultValue": "",
                             "name": "message",
-                            "type": "hal.CANMessage"
+                            "type": "hal._wpiHal.CANMessage"
                         }
                     ],
                     "declaringClassName": "wpilib.CAN",
@@ -2354,7 +2966,7 @@
                         {
                             "defaultValue": "",
                             "name": "message",
-                            "type": "hal.CANMessage"
+                            "type": "hal._wpiHal.CANMessage"
                         }
                     ],
                     "declaringClassName": "wpilib.CAN",
@@ -2415,6 +3027,56 @@
             ],
             "moduleName": "wpilib",
             "staticMethods": []
+        },
+        {
+            "className": "wpilib.CameraServer",
+            "classVariables": [],
+            "constructors": [
+                {
+                    "args": [
+                        {
+                            "defaultValue": "",
+                            "name": "args",
+                            "type": "tuple"
+                        },
+                        {
+                            "defaultValue": "",
+                            "name": "kwargs",
+                            "type": "dict"
+                        }
+                    ],
+                    "declaringClassName": "wpilib.CameraServer",
+                    "functionName": "__init__",
+                    "returnType": "wpilib.CameraServer",
+                    "tooltip": "Initialize self.  See help(type(self)) for accurate signature."
+                }
+            ],
+            "enums": [],
+            "instanceMethods": [],
+            "instanceVariables": [],
+            "moduleName": "wpilib",
+            "staticMethods": [
+                {
+                    "args": [],
+                    "declaringClassName": "wpilib.CameraServer",
+                    "functionName": "is_alive",
+                    "returnType": "bool",
+                    "tooltip": ":returns: True if the CameraServer is still alive"
+                },
+                {
+                    "args": [
+                        {
+                            "defaultValue": "",
+                            "name": "vision_py",
+                            "type": "typing.Optional[str]"
+                        }
+                    ],
+                    "declaringClassName": "wpilib.CameraServer",
+                    "functionName": "launch",
+                    "returnType": "None",
+                    "tooltip": "\n        Launches the CameraServer process in autocapture mode or\n        using a user-specified python script\n\n        :param vision_py: If specified, this is the relative path to\n                          a filename with a function in it\n\n        Example usage::\n\n            wpilib.CameraServer.launch(\"vision.py:main\")\n\n        .. warning:: You must have robotpy-cscore installed, or this\n                     function will fail without returning an error\n                     (you will see an error in the console).\n\n        "
+                }
+            ]
         },
         {
             "className": "wpilib.Color",
@@ -30048,56 +30710,6 @@
             "staticMethods": []
         },
         {
-            "className": "wpilib.cameraserver.CameraServer",
-            "classVariables": [],
-            "constructors": [
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "args",
-                            "type": "tuple"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "kwargs",
-                            "type": "dict"
-                        }
-                    ],
-                    "declaringClassName": "wpilib.cameraserver.CameraServer",
-                    "functionName": "__init__",
-                    "returnType": "wpilib.cameraserver.CameraServer",
-                    "tooltip": "Initialize self.  See help(type(self)) for accurate signature."
-                }
-            ],
-            "enums": [],
-            "instanceMethods": [],
-            "instanceVariables": [],
-            "moduleName": "wpilib.cameraserver",
-            "staticMethods": [
-                {
-                    "args": [],
-                    "declaringClassName": "wpilib.cameraserver.CameraServer",
-                    "functionName": "is_alive",
-                    "returnType": "bool",
-                    "tooltip": ":returns: True if the CameraServer is still alive"
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "vision_py",
-                            "type": "typing.Optional[str]"
-                        }
-                    ],
-                    "declaringClassName": "wpilib.cameraserver.CameraServer",
-                    "functionName": "launch",
-                    "returnType": "None",
-                    "tooltip": "\n        Launches the CameraServer process in autocapture mode or\n        using a user-specified python script\n\n        :param vision_py: If specified, this is the relative path to\n                          a filename with a function in it\n\n        Example usage::\n\n            wpilib.CameraServer.launch(\"vision.py:main\")\n\n        .. warning:: You must have robotpy-cscore installed, or this\n                     function will fail without returning an error\n                     (you will see an error in the console).\n\n        "
-                }
-            ]
-        },
-        {
             "className": "wpilib.counter.EdgeConfiguration",
             "classVariables": [
                 {
@@ -32048,7 +32660,7 @@
                 }
             ],
             "instanceVariables": [],
-            "moduleName": "wpilib._wpilib.interfaces",
+            "moduleName": "wpilib.interfaces",
             "staticMethods": []
         },
         {
@@ -32104,7 +32716,7 @@
                     "writable": false
                 }
             ],
-            "moduleName": "wpilib._wpilib.interfaces",
+            "moduleName": "wpilib.interfaces",
             "staticMethods": []
         },
         {
@@ -32684,7 +33296,7 @@
                 }
             ],
             "instanceVariables": [],
-            "moduleName": "wpilib._wpilib.interfaces",
+            "moduleName": "wpilib.interfaces",
             "staticMethods": []
         },
         {
@@ -32824,7 +33436,7 @@
                     "writable": false
                 }
             ],
-            "moduleName": "wpilib._wpilib.interfaces",
+            "moduleName": "wpilib.interfaces",
             "staticMethods": []
         },
         {
@@ -32880,7 +33492,7 @@
                     "writable": false
                 }
             ],
-            "moduleName": "wpilib._wpilib.interfaces",
+            "moduleName": "wpilib.interfaces",
             "staticMethods": []
         },
         {
@@ -33005,7 +33617,7 @@
                 }
             ],
             "instanceVariables": [],
-            "moduleName": "wpilib._wpilib.interfaces",
+            "moduleName": "wpilib.interfaces",
             "staticMethods": []
         },
         {
@@ -33130,7 +33742,7 @@
                         {
                             "defaultValue": "",
                             "name": "data",
-                            "type": "hal.AddressableLEDData"
+                            "type": "hal._wpiHal.AddressableLEDData"
                         }
                     ],
                     "declaringClassName": "wpilib.simulation.AddressableLEDSim",
@@ -33187,7 +33799,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -33210,7 +33822,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -33233,7 +33845,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -33256,7 +33868,7 @@
                         {
                             "defaultValue": "",
                             "name": "data",
-                            "type": "hal.AddressableLEDData"
+                            "type": "hal._wpiHal.AddressableLEDData"
                         }
                     ],
                     "declaringClassName": "wpilib.simulation.AddressableLEDSim",
@@ -33337,7 +33949,7 @@
                         {
                             "defaultValue": "",
                             "name": "data",
-                            "type": "hal.AddressableLEDData"
+                            "type": "hal._wpiHal.AddressableLEDData"
                         }
                     ],
                     "declaringClassName": "wpilib.simulation.AddressableLEDSim",
@@ -33378,7 +33990,7 @@
                         {
                             "defaultValue": "",
                             "name": "data",
-                            "type": "hal.AddressableLEDData"
+                            "type": "hal._wpiHal.AddressableLEDData"
                         }
                     ],
                     "declaringClassName": "wpilib.simulation.AddressableLEDSim",
@@ -33539,7 +34151,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -33562,7 +34174,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -33585,7 +34197,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -33608,7 +34220,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -33912,7 +34524,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -33935,7 +34547,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -33958,7 +34570,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -33981,7 +34593,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -34004,7 +34616,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -34032,7 +34644,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -34758,7 +35370,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -34781,7 +35393,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -34804,7 +35416,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -34827,7 +35439,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -34850,7 +35462,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -35753,7 +36365,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -35776,7 +36388,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -35799,7 +36411,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -36062,7 +36674,7 @@
                     "args": [],
                     "declaringClassName": "wpilib.simulation.DriverStationSim",
                     "functionName": "getAllianceStationId",
-                    "returnType": "hal.AllianceStationID",
+                    "returnType": "hal._wpiHal.AllianceStationID",
                     "tooltip": "Get the alliance station ID (color + number).\n\n:returns: the alliance station color and number"
                 },
                 {
@@ -36157,7 +36769,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -36175,7 +36787,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -36193,7 +36805,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -36211,7 +36823,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -36229,7 +36841,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -36247,7 +36859,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -36265,7 +36877,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -36283,7 +36895,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -36308,7 +36920,7 @@
                         {
                             "defaultValue": "",
                             "name": "allianceStationId",
-                            "type": "hal.AllianceStationID"
+                            "type": "hal._wpiHal.AllianceStationID"
                         }
                     ],
                     "declaringClassName": "wpilib.simulation.DriverStationSim",
@@ -36887,7 +37499,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -36910,7 +37522,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -36933,7 +37545,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -37615,7 +38227,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -37638,7 +38250,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -37661,7 +38273,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -37684,7 +38296,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -37707,7 +38319,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -37730,7 +38342,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -37753,7 +38365,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -37776,7 +38388,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -37799,7 +38411,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -41562,7 +42174,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -41585,7 +42197,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -41608,7 +42220,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -41819,7 +42431,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -41842,7 +42454,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -41865,7 +42477,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -41888,7 +42500,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -41916,7 +42528,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -42202,7 +42814,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -42225,7 +42837,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -42248,7 +42860,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -42271,7 +42883,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -42548,7 +43160,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -42571,7 +43183,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -42594,7 +43206,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -42617,7 +43229,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -42640,7 +43252,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -42668,7 +43280,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -42941,7 +43553,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -42959,7 +43571,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -42977,7 +43589,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -42995,7 +43607,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -43013,7 +43625,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -43031,7 +43643,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -43049,7 +43661,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -43067,7 +43679,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -43502,7 +44114,7 @@
                     ],
                     "declaringClassName": "wpilib.simulation.SimDeviceSim",
                     "functionName": "getBoolean",
-                    "returnType": "hal.SimBoolean",
+                    "returnType": "hal._wpiHal.SimBoolean",
                     "tooltip": "Retrieves an object that allows you to interact with simulated values\nrepresented as a boolean."
                 },
                 {
@@ -43520,7 +44132,7 @@
                     ],
                     "declaringClassName": "wpilib.simulation.SimDeviceSim",
                     "functionName": "getDouble",
-                    "returnType": "hal.SimDouble",
+                    "returnType": "hal._wpiHal.SimDouble",
                     "tooltip": "Retrieves an object that allows you to interact with simulated values\nrepresented as a double."
                 },
                 {
@@ -43538,7 +44150,7 @@
                     ],
                     "declaringClassName": "wpilib.simulation.SimDeviceSim",
                     "functionName": "getEnum",
-                    "returnType": "hal.SimEnum",
+                    "returnType": "hal._wpiHal.SimEnum",
                     "tooltip": "Get the property object with the given name.\n\n:param name: the property name\n\n:returns: the property object"
                 },
                 {
@@ -43556,7 +44168,7 @@
                     ],
                     "declaringClassName": "wpilib.simulation.SimDeviceSim",
                     "functionName": "getInt",
-                    "returnType": "hal.SimInt",
+                    "returnType": "hal._wpiHal.SimInt",
                     "tooltip": "Retrieves an object that allows you to interact with simulated values\nrepresented as an integer."
                 },
                 {
@@ -43574,7 +44186,7 @@
                     ],
                     "declaringClassName": "wpilib.simulation.SimDeviceSim",
                     "functionName": "getLong",
-                    "returnType": "hal.SimLong",
+                    "returnType": "hal._wpiHal.SimLong",
                     "tooltip": "Retrieves an object that allows you to interact with simulated values\nrepresented as a long."
                 },
                 {
@@ -43605,7 +44217,7 @@
                     ],
                     "declaringClassName": "wpilib.simulation.SimDeviceSim",
                     "functionName": "getValue",
-                    "returnType": "hal.SimValue",
+                    "returnType": "hal._wpiHal.SimValue",
                     "tooltip": "Provides a readonly mechanism to retrieve all types of device values"
                 }
             ],
@@ -43630,7 +44242,7 @@
                         {
                             "defaultValue": "",
                             "name": "val",
-                            "type": "hal.SimEnum"
+                            "type": "hal._wpiHal.SimEnum"
                         }
                     ],
                     "declaringClassName": "wpilib.simulation.SimDeviceSim",
@@ -44175,7 +44787,7 @@
                         {
                             "defaultValue": "",
                             "name": "callback",
-                            "type": "Callable[[str, hal.Value], None]"
+                            "type": "Callable[[str, hal._wpiHal.Value], None]"
                         },
                         {
                             "defaultValue": "",
@@ -53671,7 +54283,7 @@
                         {
                             "defaultValue": "",
                             "name": "odometry",
-                            "type": "wpimath.kinematics.DifferentialDriveOdometry3dBase"
+                            "type": "wpimath.kinematics._kinematics.DifferentialDriveOdometry3dBase"
                         },
                         {
                             "defaultValue": "",
@@ -57308,7 +57920,7 @@
                         {
                             "defaultValue": "",
                             "name": "odometry",
-                            "type": "wpimath.kinematics.MecanumDriveOdometry3dBase"
+                            "type": "wpimath.kinematics._kinematics.MecanumDriveOdometry3dBase"
                         },
                         {
                             "defaultValue": "",
@@ -58476,7 +59088,7 @@
                         {
                             "defaultValue": "",
                             "name": "odometry",
-                            "type": "wpimath.kinematics.SwerveDrive2Odometry3dBase"
+                            "type": "wpimath.kinematics._kinematics.SwerveDrive2Odometry3dBase"
                         },
                         {
                             "defaultValue": "",
@@ -59644,7 +60256,7 @@
                         {
                             "defaultValue": "",
                             "name": "odometry",
-                            "type": "wpimath.kinematics.SwerveDrive3Odometry3dBase"
+                            "type": "wpimath.kinematics._kinematics.SwerveDrive3Odometry3dBase"
                         },
                         {
                             "defaultValue": "",
@@ -60812,7 +61424,7 @@
                         {
                             "defaultValue": "",
                             "name": "odometry",
-                            "type": "wpimath.kinematics.SwerveDrive4Odometry3dBase"
+                            "type": "wpimath.kinematics._kinematics.SwerveDrive4Odometry3dBase"
                         },
                         {
                             "defaultValue": "",
@@ -61980,7 +62592,7 @@
                         {
                             "defaultValue": "",
                             "name": "odometry",
-                            "type": "wpimath.kinematics.SwerveDrive6Odometry3dBase"
+                            "type": "wpimath.kinematics._kinematics.SwerveDrive6Odometry3dBase"
                         },
                         {
                             "defaultValue": "",
@@ -67957,332 +68569,6 @@
             "staticMethods": []
         },
         {
-            "className": "wpimath.kinematics.DifferentialDriveOdometry3d",
-            "classVariables": [],
-            "constructors": [
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "gyroAngle",
-                            "type": "wpimath.geometry.Rotation3d"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "leftDistance",
-                            "type": "wpimath.units.meters"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "rightDistance",
-                            "type": "wpimath.units.meters"
-                        },
-                        {
-                            "defaultValue": "Pose3d(Translation3d(x=0.000000, y=0.000000, z=0.000000), Rotation3d(x=0.000000, y=0.000000, z=0.000000))",
-                            "name": "initialPose",
-                            "type": "wpimath.geometry.Pose3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.DifferentialDriveOdometry3d",
-                    "functionName": "__init__",
-                    "returnType": "wpimath.kinematics.DifferentialDriveOdometry3d",
-                    "tooltip": "Constructs a DifferentialDriveOdometry3d object.\n\nIF leftDistance and rightDistance are unspecified,\nYou NEED to reset your encoders (to zero).\n\n:param gyroAngle:     The angle reported by the gyroscope.\n:param leftDistance:  The distance traveled by the left encoder.\n:param rightDistance: The distance traveled by the right encoder.\n:param initialPose:   The starting position of the robot on the field."
-                }
-            ],
-            "enums": [],
-            "instanceMethods": [
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.DifferentialDriveOdometry3dBase"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.DifferentialDriveOdometry3dBase",
-                    "functionName": "getPose",
-                    "returnType": "wpimath.geometry.Pose3d",
-                    "tooltip": "Returns the position of the robot on the field.\n\n:returns: The pose of the robot."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.DifferentialDriveOdometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "pose",
-                            "type": "wpimath.geometry.Pose3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.DifferentialDriveOdometry3dBase",
-                    "functionName": "resetPose",
-                    "returnType": "None",
-                    "tooltip": "Resets the pose.\n\n:param pose: The pose to reset to."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.DifferentialDriveOdometry3d"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "gyroAngle",
-                            "type": "wpimath.geometry.Rotation3d"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "leftDistance",
-                            "type": "wpimath.units.meters"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "rightDistance",
-                            "type": "wpimath.units.meters"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "pose",
-                            "type": "wpimath.geometry.Pose3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.DifferentialDriveOdometry3d",
-                    "functionName": "resetPosition",
-                    "returnType": "None",
-                    "tooltip": "Resets the robot's position on the field.\n\nIF leftDistance and rightDistance are unspecified,\nYou NEED to reset your encoders (to zero).\n\nThe gyroscope angle does not need to be reset here on the user's robot\ncode. The library automatically takes care of offsetting the gyro angle.\n\n:param pose:          The position on the field that your robot is at.\n:param gyroAngle:     The angle reported by the gyroscope.\n:param leftDistance:  The distance traveled by the left encoder.\n:param rightDistance: The distance traveled by the right encoder."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.DifferentialDriveOdometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "rotation",
-                            "type": "wpimath.geometry.Rotation3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.DifferentialDriveOdometry3dBase",
-                    "functionName": "resetRotation",
-                    "returnType": "None",
-                    "tooltip": "Resets the rotation of the pose.\n\n:param rotation: The rotation to reset to."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.DifferentialDriveOdometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "translation",
-                            "type": "wpimath.geometry.Translation3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.DifferentialDriveOdometry3dBase",
-                    "functionName": "resetTranslation",
-                    "returnType": "None",
-                    "tooltip": "Resets the translation of the pose.\n\n:param translation: The translation to reset to."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.DifferentialDriveOdometry3d"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "gyroAngle",
-                            "type": "wpimath.geometry.Rotation3d"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "leftDistance",
-                            "type": "wpimath.units.meters"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "rightDistance",
-                            "type": "wpimath.units.meters"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.DifferentialDriveOdometry3d",
-                    "functionName": "update",
-                    "returnType": "wpimath.geometry.Pose3d",
-                    "tooltip": "Updates the robot position on the field using distance measurements from\nencoders. This method is more numerically accurate than using velocities to\nintegrate the pose and is also advantageous for teams that are using lower\nCPR encoders.\n\n:param gyroAngle:     The angle reported by the gyroscope.\n:param leftDistance:  The distance traveled by the left encoder.\n:param rightDistance: The distance traveled by the right encoder.\n\n:returns: The new pose of the robot."
-                }
-            ],
-            "instanceVariables": [],
-            "moduleName": "wpimath.kinematics",
-            "staticMethods": []
-        },
-        {
-            "className": "wpimath.kinematics.DifferentialDriveOdometry3dBase",
-            "classVariables": [],
-            "constructors": [
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "kinematics",
-                            "type": "wpimath.kinematics.DifferentialDriveKinematicsBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "gyroAngle",
-                            "type": "wpimath.geometry.Rotation3d"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "wheelPositions",
-                            "type": "wpimath.kinematics.DifferentialDriveWheelPositions"
-                        },
-                        {
-                            "defaultValue": "Pose3d(Translation3d(x=0.000000, y=0.000000, z=0.000000), Rotation3d(x=0.000000, y=0.000000, z=0.000000))",
-                            "name": "initialPose",
-                            "type": "wpimath.geometry.Pose3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.DifferentialDriveOdometry3dBase",
-                    "functionName": "__init__",
-                    "returnType": "wpimath.kinematics.DifferentialDriveOdometry3dBase",
-                    "tooltip": "Constructs an Odometry3d object.\n\n:param kinematics:     The kinematics for your drivetrain.\n:param gyroAngle:      The angle reported by the gyroscope.\n:param wheelPositions: The current distances measured by each wheel.\n:param initialPose:    The starting position of the robot on the field."
-                }
-            ],
-            "enums": [],
-            "instanceMethods": [
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.DifferentialDriveOdometry3dBase"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.DifferentialDriveOdometry3dBase",
-                    "functionName": "getPose",
-                    "returnType": "wpimath.geometry.Pose3d",
-                    "tooltip": "Returns the position of the robot on the field.\n\n:returns: The pose of the robot."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.DifferentialDriveOdometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "pose",
-                            "type": "wpimath.geometry.Pose3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.DifferentialDriveOdometry3dBase",
-                    "functionName": "resetPose",
-                    "returnType": "None",
-                    "tooltip": "Resets the pose.\n\n:param pose: The pose to reset to."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.DifferentialDriveOdometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "gyroAngle",
-                            "type": "wpimath.geometry.Rotation3d"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "wheelPositions",
-                            "type": "wpimath.kinematics.DifferentialDriveWheelPositions"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "pose",
-                            "type": "wpimath.geometry.Pose3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.DifferentialDriveOdometry3dBase",
-                    "functionName": "resetPosition",
-                    "returnType": "None",
-                    "tooltip": "Resets the robot's position on the field.\n\nThe gyroscope angle does not need to be reset here on the user's robot\ncode. The library automatically takes care of offsetting the gyro angle.\n\n:param gyroAngle:      The angle reported by the gyroscope.\n:param wheelPositions: The current distances measured by each wheel.\n:param pose:           The position on the field that your robot is at."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.DifferentialDriveOdometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "rotation",
-                            "type": "wpimath.geometry.Rotation3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.DifferentialDriveOdometry3dBase",
-                    "functionName": "resetRotation",
-                    "returnType": "None",
-                    "tooltip": "Resets the rotation of the pose.\n\n:param rotation: The rotation to reset to."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.DifferentialDriveOdometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "translation",
-                            "type": "wpimath.geometry.Translation3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.DifferentialDriveOdometry3dBase",
-                    "functionName": "resetTranslation",
-                    "returnType": "None",
-                    "tooltip": "Resets the translation of the pose.\n\n:param translation: The translation to reset to."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.DifferentialDriveOdometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "gyroAngle",
-                            "type": "wpimath.geometry.Rotation3d"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "wheelPositions",
-                            "type": "wpimath.kinematics.DifferentialDriveWheelPositions"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.DifferentialDriveOdometry3dBase",
-                    "functionName": "update",
-                    "returnType": "wpimath.geometry.Pose3d",
-                    "tooltip": "Updates the robot's position on the field using forward kinematics and\nintegration of the pose over time. This method takes in an angle parameter\nwhich is used instead of the angular rate that is calculated from forward\nkinematics, in addition to the current distance measurement at each wheel.\n\n:param gyroAngle:      The angle reported by the gyroscope.\n:param wheelPositions: The current distances measured by each wheel.\n\n:returns: The new pose of the robot."
-                }
-            ],
-            "instanceVariables": [],
-            "moduleName": "wpimath.kinematics",
-            "staticMethods": []
-        },
-        {
             "className": "wpimath.kinematics.DifferentialDriveOdometryBase",
             "classVariables": [],
             "constructors": [
@@ -69064,322 +69350,6 @@
                     "declaringClassName": "wpimath.kinematics.MecanumDriveOdometryBase",
                     "functionName": "update",
                     "returnType": "wpimath.geometry.Pose2d",
-                    "tooltip": "Updates the robot's position on the field using forward kinematics and\nintegration of the pose over time. This method takes in an angle parameter\nwhich is used instead of the angular rate that is calculated from forward\nkinematics, in addition to the current distance measurement at each wheel.\n\n:param gyroAngle:      The angle reported by the gyroscope.\n:param wheelPositions: The current distances measured by each wheel.\n\n:returns: The new pose of the robot."
-                }
-            ],
-            "instanceVariables": [],
-            "moduleName": "wpimath.kinematics",
-            "staticMethods": []
-        },
-        {
-            "className": "wpimath.kinematics.MecanumDriveOdometry3d",
-            "classVariables": [],
-            "constructors": [
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "kinematics",
-                            "type": "wpimath.kinematics.MecanumDriveKinematics"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "gyroAngle",
-                            "type": "wpimath.geometry.Rotation3d"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "wheelPositions",
-                            "type": "wpimath.kinematics.MecanumDriveWheelPositions"
-                        },
-                        {
-                            "defaultValue": "Pose3d(Translation3d(x=0.000000, y=0.000000, z=0.000000), Rotation3d(x=0.000000, y=0.000000, z=0.000000))",
-                            "name": "initialPose",
-                            "type": "wpimath.geometry.Pose3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.MecanumDriveOdometry3d",
-                    "functionName": "__init__",
-                    "returnType": "wpimath.kinematics.MecanumDriveOdometry3d",
-                    "tooltip": "Constructs a MecanumDriveOdometry3d object.\n\n:param kinematics:     The mecanum drive kinematics for your drivetrain.\n:param gyroAngle:      The angle reported by the gyroscope.\n:param wheelPositions: The current distances measured by each wheel.\n:param initialPose:    The starting position of the robot on the field."
-                }
-            ],
-            "enums": [],
-            "instanceMethods": [
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.MecanumDriveOdometry3dBase"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.MecanumDriveOdometry3dBase",
-                    "functionName": "getPose",
-                    "returnType": "wpimath.geometry.Pose3d",
-                    "tooltip": "Returns the position of the robot on the field.\n\n:returns: The pose of the robot."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.MecanumDriveOdometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "pose",
-                            "type": "wpimath.geometry.Pose3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.MecanumDriveOdometry3dBase",
-                    "functionName": "resetPose",
-                    "returnType": "None",
-                    "tooltip": "Resets the pose.\n\n:param pose: The pose to reset to."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.MecanumDriveOdometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "gyroAngle",
-                            "type": "wpimath.geometry.Rotation3d"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "wheelPositions",
-                            "type": "wpimath.kinematics.MecanumDriveWheelPositions"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "pose",
-                            "type": "wpimath.geometry.Pose3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.MecanumDriveOdometry3dBase",
-                    "functionName": "resetPosition",
-                    "returnType": "None",
-                    "tooltip": "Resets the robot's position on the field.\n\nThe gyroscope angle does not need to be reset here on the user's robot\ncode. The library automatically takes care of offsetting the gyro angle.\n\n:param gyroAngle:      The angle reported by the gyroscope.\n:param wheelPositions: The current distances measured by each wheel.\n:param pose:           The position on the field that your robot is at."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.MecanumDriveOdometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "rotation",
-                            "type": "wpimath.geometry.Rotation3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.MecanumDriveOdometry3dBase",
-                    "functionName": "resetRotation",
-                    "returnType": "None",
-                    "tooltip": "Resets the rotation of the pose.\n\n:param rotation: The rotation to reset to."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.MecanumDriveOdometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "translation",
-                            "type": "wpimath.geometry.Translation3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.MecanumDriveOdometry3dBase",
-                    "functionName": "resetTranslation",
-                    "returnType": "None",
-                    "tooltip": "Resets the translation of the pose.\n\n:param translation: The translation to reset to."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.MecanumDriveOdometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "gyroAngle",
-                            "type": "wpimath.geometry.Rotation3d"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "wheelPositions",
-                            "type": "wpimath.kinematics.MecanumDriveWheelPositions"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.MecanumDriveOdometry3dBase",
-                    "functionName": "update",
-                    "returnType": "wpimath.geometry.Pose3d",
-                    "tooltip": "Updates the robot's position on the field using forward kinematics and\nintegration of the pose over time. This method takes in an angle parameter\nwhich is used instead of the angular rate that is calculated from forward\nkinematics, in addition to the current distance measurement at each wheel.\n\n:param gyroAngle:      The angle reported by the gyroscope.\n:param wheelPositions: The current distances measured by each wheel.\n\n:returns: The new pose of the robot."
-                }
-            ],
-            "instanceVariables": [],
-            "moduleName": "wpimath.kinematics",
-            "staticMethods": []
-        },
-        {
-            "className": "wpimath.kinematics.MecanumDriveOdometry3dBase",
-            "classVariables": [],
-            "constructors": [
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "kinematics",
-                            "type": "wpimath.kinematics.MecanumDriveKinematicsBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "gyroAngle",
-                            "type": "wpimath.geometry.Rotation3d"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "wheelPositions",
-                            "type": "wpimath.kinematics.MecanumDriveWheelPositions"
-                        },
-                        {
-                            "defaultValue": "Pose3d(Translation3d(x=0.000000, y=0.000000, z=0.000000), Rotation3d(x=0.000000, y=0.000000, z=0.000000))",
-                            "name": "initialPose",
-                            "type": "wpimath.geometry.Pose3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.MecanumDriveOdometry3dBase",
-                    "functionName": "__init__",
-                    "returnType": "wpimath.kinematics.MecanumDriveOdometry3dBase",
-                    "tooltip": "Constructs an Odometry3d object.\n\n:param kinematics:     The kinematics for your drivetrain.\n:param gyroAngle:      The angle reported by the gyroscope.\n:param wheelPositions: The current distances measured by each wheel.\n:param initialPose:    The starting position of the robot on the field."
-                }
-            ],
-            "enums": [],
-            "instanceMethods": [
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.MecanumDriveOdometry3dBase"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.MecanumDriveOdometry3dBase",
-                    "functionName": "getPose",
-                    "returnType": "wpimath.geometry.Pose3d",
-                    "tooltip": "Returns the position of the robot on the field.\n\n:returns: The pose of the robot."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.MecanumDriveOdometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "pose",
-                            "type": "wpimath.geometry.Pose3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.MecanumDriveOdometry3dBase",
-                    "functionName": "resetPose",
-                    "returnType": "None",
-                    "tooltip": "Resets the pose.\n\n:param pose: The pose to reset to."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.MecanumDriveOdometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "gyroAngle",
-                            "type": "wpimath.geometry.Rotation3d"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "wheelPositions",
-                            "type": "wpimath.kinematics.MecanumDriveWheelPositions"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "pose",
-                            "type": "wpimath.geometry.Pose3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.MecanumDriveOdometry3dBase",
-                    "functionName": "resetPosition",
-                    "returnType": "None",
-                    "tooltip": "Resets the robot's position on the field.\n\nThe gyroscope angle does not need to be reset here on the user's robot\ncode. The library automatically takes care of offsetting the gyro angle.\n\n:param gyroAngle:      The angle reported by the gyroscope.\n:param wheelPositions: The current distances measured by each wheel.\n:param pose:           The position on the field that your robot is at."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.MecanumDriveOdometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "rotation",
-                            "type": "wpimath.geometry.Rotation3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.MecanumDriveOdometry3dBase",
-                    "functionName": "resetRotation",
-                    "returnType": "None",
-                    "tooltip": "Resets the rotation of the pose.\n\n:param rotation: The rotation to reset to."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.MecanumDriveOdometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "translation",
-                            "type": "wpimath.geometry.Translation3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.MecanumDriveOdometry3dBase",
-                    "functionName": "resetTranslation",
-                    "returnType": "None",
-                    "tooltip": "Resets the translation of the pose.\n\n:param translation: The translation to reset to."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.MecanumDriveOdometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "gyroAngle",
-                            "type": "wpimath.geometry.Rotation3d"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "wheelPositions",
-                            "type": "wpimath.kinematics.MecanumDriveWheelPositions"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.MecanumDriveOdometry3dBase",
-                    "functionName": "update",
-                    "returnType": "wpimath.geometry.Pose3d",
                     "tooltip": "Updates the robot's position on the field using forward kinematics and\nintegration of the pose over time. This method takes in an angle parameter\nwhich is used instead of the angular rate that is calculated from forward\nkinematics, in addition to the current distance measurement at each wheel.\n\n:param gyroAngle:      The angle reported by the gyroscope.\n:param wheelPositions: The current distances measured by each wheel.\n\n:returns: The new pose of the robot."
                 }
             ],
@@ -70254,322 +70224,6 @@
             "staticMethods": []
         },
         {
-            "className": "wpimath.kinematics.SwerveDrive2Odometry3d",
-            "classVariables": [],
-            "constructors": [
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "kinematics",
-                            "type": "wpimath.kinematics.SwerveDrive2Kinematics"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "gyroAngle",
-                            "type": "wpimath.geometry.Rotation3d"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "modulePositions",
-                            "type": "Tuple[wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition]"
-                        },
-                        {
-                            "defaultValue": "Pose3d(Translation3d(x=0.000000, y=0.000000, z=0.000000), Rotation3d(x=0.000000, y=0.000000, z=0.000000))",
-                            "name": "initialPose",
-                            "type": "wpimath.geometry.Pose3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive2Odometry3d",
-                    "functionName": "__init__",
-                    "returnType": "wpimath.kinematics.SwerveDrive2Odometry3d",
-                    "tooltip": ""
-                }
-            ],
-            "enums": [],
-            "instanceMethods": [
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.SwerveDrive2Odometry3dBase"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive2Odometry3dBase",
-                    "functionName": "getPose",
-                    "returnType": "wpimath.geometry.Pose3d",
-                    "tooltip": "Returns the position of the robot on the field.\n\n:returns: The pose of the robot."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.SwerveDrive2Odometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "pose",
-                            "type": "wpimath.geometry.Pose3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive2Odometry3dBase",
-                    "functionName": "resetPose",
-                    "returnType": "None",
-                    "tooltip": "Resets the pose.\n\n:param pose: The pose to reset to."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.SwerveDrive2Odometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "gyroAngle",
-                            "type": "wpimath.geometry.Rotation3d"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "wheelPositions",
-                            "type": "Tuple[wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition]"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "pose",
-                            "type": "wpimath.geometry.Pose3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive2Odometry3dBase",
-                    "functionName": "resetPosition",
-                    "returnType": "None",
-                    "tooltip": "Resets the robot's position on the field.\n\nThe gyroscope angle does not need to be reset here on the user's robot\ncode. The library automatically takes care of offsetting the gyro angle.\n\n:param gyroAngle:      The angle reported by the gyroscope.\n:param wheelPositions: The current distances measured by each wheel.\n:param pose:           The position on the field that your robot is at."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.SwerveDrive2Odometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "rotation",
-                            "type": "wpimath.geometry.Rotation3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive2Odometry3dBase",
-                    "functionName": "resetRotation",
-                    "returnType": "None",
-                    "tooltip": "Resets the rotation of the pose.\n\n:param rotation: The rotation to reset to."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.SwerveDrive2Odometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "translation",
-                            "type": "wpimath.geometry.Translation3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive2Odometry3dBase",
-                    "functionName": "resetTranslation",
-                    "returnType": "None",
-                    "tooltip": "Resets the translation of the pose.\n\n:param translation: The translation to reset to."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.SwerveDrive2Odometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "gyroAngle",
-                            "type": "wpimath.geometry.Rotation3d"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "wheelPositions",
-                            "type": "Tuple[wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition]"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive2Odometry3dBase",
-                    "functionName": "update",
-                    "returnType": "wpimath.geometry.Pose3d",
-                    "tooltip": "Updates the robot's position on the field using forward kinematics and\nintegration of the pose over time. This method takes in an angle parameter\nwhich is used instead of the angular rate that is calculated from forward\nkinematics, in addition to the current distance measurement at each wheel.\n\n:param gyroAngle:      The angle reported by the gyroscope.\n:param wheelPositions: The current distances measured by each wheel.\n\n:returns: The new pose of the robot."
-                }
-            ],
-            "instanceVariables": [],
-            "moduleName": "wpimath.kinematics",
-            "staticMethods": []
-        },
-        {
-            "className": "wpimath.kinematics.SwerveDrive2Odometry3dBase",
-            "classVariables": [],
-            "constructors": [
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "kinematics",
-                            "type": "wpimath.kinematics.SwerveDrive2KinematicsBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "gyroAngle",
-                            "type": "wpimath.geometry.Rotation3d"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "wheelPositions",
-                            "type": "Tuple[wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition]"
-                        },
-                        {
-                            "defaultValue": "Pose3d(Translation3d(x=0.000000, y=0.000000, z=0.000000), Rotation3d(x=0.000000, y=0.000000, z=0.000000))",
-                            "name": "initialPose",
-                            "type": "wpimath.geometry.Pose3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive2Odometry3dBase",
-                    "functionName": "__init__",
-                    "returnType": "wpimath.kinematics.SwerveDrive2Odometry3dBase",
-                    "tooltip": "Constructs an Odometry3d object.\n\n:param kinematics:     The kinematics for your drivetrain.\n:param gyroAngle:      The angle reported by the gyroscope.\n:param wheelPositions: The current distances measured by each wheel.\n:param initialPose:    The starting position of the robot on the field."
-                }
-            ],
-            "enums": [],
-            "instanceMethods": [
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.SwerveDrive2Odometry3dBase"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive2Odometry3dBase",
-                    "functionName": "getPose",
-                    "returnType": "wpimath.geometry.Pose3d",
-                    "tooltip": "Returns the position of the robot on the field.\n\n:returns: The pose of the robot."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.SwerveDrive2Odometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "pose",
-                            "type": "wpimath.geometry.Pose3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive2Odometry3dBase",
-                    "functionName": "resetPose",
-                    "returnType": "None",
-                    "tooltip": "Resets the pose.\n\n:param pose: The pose to reset to."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.SwerveDrive2Odometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "gyroAngle",
-                            "type": "wpimath.geometry.Rotation3d"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "wheelPositions",
-                            "type": "Tuple[wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition]"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "pose",
-                            "type": "wpimath.geometry.Pose3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive2Odometry3dBase",
-                    "functionName": "resetPosition",
-                    "returnType": "None",
-                    "tooltip": "Resets the robot's position on the field.\n\nThe gyroscope angle does not need to be reset here on the user's robot\ncode. The library automatically takes care of offsetting the gyro angle.\n\n:param gyroAngle:      The angle reported by the gyroscope.\n:param wheelPositions: The current distances measured by each wheel.\n:param pose:           The position on the field that your robot is at."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.SwerveDrive2Odometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "rotation",
-                            "type": "wpimath.geometry.Rotation3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive2Odometry3dBase",
-                    "functionName": "resetRotation",
-                    "returnType": "None",
-                    "tooltip": "Resets the rotation of the pose.\n\n:param rotation: The rotation to reset to."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.SwerveDrive2Odometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "translation",
-                            "type": "wpimath.geometry.Translation3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive2Odometry3dBase",
-                    "functionName": "resetTranslation",
-                    "returnType": "None",
-                    "tooltip": "Resets the translation of the pose.\n\n:param translation: The translation to reset to."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.SwerveDrive2Odometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "gyroAngle",
-                            "type": "wpimath.geometry.Rotation3d"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "wheelPositions",
-                            "type": "Tuple[wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition]"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive2Odometry3dBase",
-                    "functionName": "update",
-                    "returnType": "wpimath.geometry.Pose3d",
-                    "tooltip": "Updates the robot's position on the field using forward kinematics and\nintegration of the pose over time. This method takes in an angle parameter\nwhich is used instead of the angular rate that is calculated from forward\nkinematics, in addition to the current distance measurement at each wheel.\n\n:param gyroAngle:      The angle reported by the gyroscope.\n:param wheelPositions: The current distances measured by each wheel.\n\n:returns: The new pose of the robot."
-                }
-            ],
-            "instanceVariables": [],
-            "moduleName": "wpimath.kinematics",
-            "staticMethods": []
-        },
-        {
             "className": "wpimath.kinematics.SwerveDrive2OdometryBase",
             "classVariables": [],
             "constructors": [
@@ -71230,322 +70884,6 @@
                     "declaringClassName": "wpimath.kinematics.SwerveDrive3OdometryBase",
                     "functionName": "update",
                     "returnType": "wpimath.geometry.Pose2d",
-                    "tooltip": "Updates the robot's position on the field using forward kinematics and\nintegration of the pose over time. This method takes in an angle parameter\nwhich is used instead of the angular rate that is calculated from forward\nkinematics, in addition to the current distance measurement at each wheel.\n\n:param gyroAngle:      The angle reported by the gyroscope.\n:param wheelPositions: The current distances measured by each wheel.\n\n:returns: The new pose of the robot."
-                }
-            ],
-            "instanceVariables": [],
-            "moduleName": "wpimath.kinematics",
-            "staticMethods": []
-        },
-        {
-            "className": "wpimath.kinematics.SwerveDrive3Odometry3d",
-            "classVariables": [],
-            "constructors": [
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "kinematics",
-                            "type": "wpimath.kinematics.SwerveDrive3Kinematics"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "gyroAngle",
-                            "type": "wpimath.geometry.Rotation3d"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "modulePositions",
-                            "type": "Tuple[wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition]"
-                        },
-                        {
-                            "defaultValue": "Pose3d(Translation3d(x=0.000000, y=0.000000, z=0.000000), Rotation3d(x=0.000000, y=0.000000, z=0.000000))",
-                            "name": "initialPose",
-                            "type": "wpimath.geometry.Pose3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive3Odometry3d",
-                    "functionName": "__init__",
-                    "returnType": "wpimath.kinematics.SwerveDrive3Odometry3d",
-                    "tooltip": ""
-                }
-            ],
-            "enums": [],
-            "instanceMethods": [
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.SwerveDrive3Odometry3dBase"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive3Odometry3dBase",
-                    "functionName": "getPose",
-                    "returnType": "wpimath.geometry.Pose3d",
-                    "tooltip": "Returns the position of the robot on the field.\n\n:returns: The pose of the robot."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.SwerveDrive3Odometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "pose",
-                            "type": "wpimath.geometry.Pose3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive3Odometry3dBase",
-                    "functionName": "resetPose",
-                    "returnType": "None",
-                    "tooltip": "Resets the pose.\n\n:param pose: The pose to reset to."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.SwerveDrive3Odometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "gyroAngle",
-                            "type": "wpimath.geometry.Rotation3d"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "wheelPositions",
-                            "type": "Tuple[wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition]"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "pose",
-                            "type": "wpimath.geometry.Pose3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive3Odometry3dBase",
-                    "functionName": "resetPosition",
-                    "returnType": "None",
-                    "tooltip": "Resets the robot's position on the field.\n\nThe gyroscope angle does not need to be reset here on the user's robot\ncode. The library automatically takes care of offsetting the gyro angle.\n\n:param gyroAngle:      The angle reported by the gyroscope.\n:param wheelPositions: The current distances measured by each wheel.\n:param pose:           The position on the field that your robot is at."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.SwerveDrive3Odometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "rotation",
-                            "type": "wpimath.geometry.Rotation3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive3Odometry3dBase",
-                    "functionName": "resetRotation",
-                    "returnType": "None",
-                    "tooltip": "Resets the rotation of the pose.\n\n:param rotation: The rotation to reset to."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.SwerveDrive3Odometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "translation",
-                            "type": "wpimath.geometry.Translation3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive3Odometry3dBase",
-                    "functionName": "resetTranslation",
-                    "returnType": "None",
-                    "tooltip": "Resets the translation of the pose.\n\n:param translation: The translation to reset to."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.SwerveDrive3Odometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "gyroAngle",
-                            "type": "wpimath.geometry.Rotation3d"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "wheelPositions",
-                            "type": "Tuple[wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition]"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive3Odometry3dBase",
-                    "functionName": "update",
-                    "returnType": "wpimath.geometry.Pose3d",
-                    "tooltip": "Updates the robot's position on the field using forward kinematics and\nintegration of the pose over time. This method takes in an angle parameter\nwhich is used instead of the angular rate that is calculated from forward\nkinematics, in addition to the current distance measurement at each wheel.\n\n:param gyroAngle:      The angle reported by the gyroscope.\n:param wheelPositions: The current distances measured by each wheel.\n\n:returns: The new pose of the robot."
-                }
-            ],
-            "instanceVariables": [],
-            "moduleName": "wpimath.kinematics",
-            "staticMethods": []
-        },
-        {
-            "className": "wpimath.kinematics.SwerveDrive3Odometry3dBase",
-            "classVariables": [],
-            "constructors": [
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "kinematics",
-                            "type": "wpimath.kinematics.SwerveDrive3KinematicsBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "gyroAngle",
-                            "type": "wpimath.geometry.Rotation3d"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "wheelPositions",
-                            "type": "Tuple[wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition]"
-                        },
-                        {
-                            "defaultValue": "Pose3d(Translation3d(x=0.000000, y=0.000000, z=0.000000), Rotation3d(x=0.000000, y=0.000000, z=0.000000))",
-                            "name": "initialPose",
-                            "type": "wpimath.geometry.Pose3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive3Odometry3dBase",
-                    "functionName": "__init__",
-                    "returnType": "wpimath.kinematics.SwerveDrive3Odometry3dBase",
-                    "tooltip": "Constructs an Odometry3d object.\n\n:param kinematics:     The kinematics for your drivetrain.\n:param gyroAngle:      The angle reported by the gyroscope.\n:param wheelPositions: The current distances measured by each wheel.\n:param initialPose:    The starting position of the robot on the field."
-                }
-            ],
-            "enums": [],
-            "instanceMethods": [
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.SwerveDrive3Odometry3dBase"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive3Odometry3dBase",
-                    "functionName": "getPose",
-                    "returnType": "wpimath.geometry.Pose3d",
-                    "tooltip": "Returns the position of the robot on the field.\n\n:returns: The pose of the robot."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.SwerveDrive3Odometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "pose",
-                            "type": "wpimath.geometry.Pose3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive3Odometry3dBase",
-                    "functionName": "resetPose",
-                    "returnType": "None",
-                    "tooltip": "Resets the pose.\n\n:param pose: The pose to reset to."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.SwerveDrive3Odometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "gyroAngle",
-                            "type": "wpimath.geometry.Rotation3d"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "wheelPositions",
-                            "type": "Tuple[wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition]"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "pose",
-                            "type": "wpimath.geometry.Pose3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive3Odometry3dBase",
-                    "functionName": "resetPosition",
-                    "returnType": "None",
-                    "tooltip": "Resets the robot's position on the field.\n\nThe gyroscope angle does not need to be reset here on the user's robot\ncode. The library automatically takes care of offsetting the gyro angle.\n\n:param gyroAngle:      The angle reported by the gyroscope.\n:param wheelPositions: The current distances measured by each wheel.\n:param pose:           The position on the field that your robot is at."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.SwerveDrive3Odometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "rotation",
-                            "type": "wpimath.geometry.Rotation3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive3Odometry3dBase",
-                    "functionName": "resetRotation",
-                    "returnType": "None",
-                    "tooltip": "Resets the rotation of the pose.\n\n:param rotation: The rotation to reset to."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.SwerveDrive3Odometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "translation",
-                            "type": "wpimath.geometry.Translation3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive3Odometry3dBase",
-                    "functionName": "resetTranslation",
-                    "returnType": "None",
-                    "tooltip": "Resets the translation of the pose.\n\n:param translation: The translation to reset to."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.SwerveDrive3Odometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "gyroAngle",
-                            "type": "wpimath.geometry.Rotation3d"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "wheelPositions",
-                            "type": "Tuple[wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition]"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive3Odometry3dBase",
-                    "functionName": "update",
-                    "returnType": "wpimath.geometry.Pose3d",
                     "tooltip": "Updates the robot's position on the field using forward kinematics and\nintegration of the pose over time. This method takes in an angle parameter\nwhich is used instead of the angular rate that is calculated from forward\nkinematics, in addition to the current distance measurement at each wheel.\n\n:param gyroAngle:      The angle reported by the gyroscope.\n:param wheelPositions: The current distances measured by each wheel.\n\n:returns: The new pose of the robot."
                 }
             ],
@@ -72219,322 +71557,6 @@
                     "declaringClassName": "wpimath.kinematics.SwerveDrive4OdometryBase",
                     "functionName": "update",
                     "returnType": "wpimath.geometry.Pose2d",
-                    "tooltip": "Updates the robot's position on the field using forward kinematics and\nintegration of the pose over time. This method takes in an angle parameter\nwhich is used instead of the angular rate that is calculated from forward\nkinematics, in addition to the current distance measurement at each wheel.\n\n:param gyroAngle:      The angle reported by the gyroscope.\n:param wheelPositions: The current distances measured by each wheel.\n\n:returns: The new pose of the robot."
-                }
-            ],
-            "instanceVariables": [],
-            "moduleName": "wpimath.kinematics",
-            "staticMethods": []
-        },
-        {
-            "className": "wpimath.kinematics.SwerveDrive4Odometry3d",
-            "classVariables": [],
-            "constructors": [
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "kinematics",
-                            "type": "wpimath.kinematics.SwerveDrive4Kinematics"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "gyroAngle",
-                            "type": "wpimath.geometry.Rotation3d"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "modulePositions",
-                            "type": "Tuple[wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition]"
-                        },
-                        {
-                            "defaultValue": "Pose3d(Translation3d(x=0.000000, y=0.000000, z=0.000000), Rotation3d(x=0.000000, y=0.000000, z=0.000000))",
-                            "name": "initialPose",
-                            "type": "wpimath.geometry.Pose3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive4Odometry3d",
-                    "functionName": "__init__",
-                    "returnType": "wpimath.kinematics.SwerveDrive4Odometry3d",
-                    "tooltip": ""
-                }
-            ],
-            "enums": [],
-            "instanceMethods": [
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.SwerveDrive4Odometry3dBase"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive4Odometry3dBase",
-                    "functionName": "getPose",
-                    "returnType": "wpimath.geometry.Pose3d",
-                    "tooltip": "Returns the position of the robot on the field.\n\n:returns: The pose of the robot."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.SwerveDrive4Odometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "pose",
-                            "type": "wpimath.geometry.Pose3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive4Odometry3dBase",
-                    "functionName": "resetPose",
-                    "returnType": "None",
-                    "tooltip": "Resets the pose.\n\n:param pose: The pose to reset to."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.SwerveDrive4Odometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "gyroAngle",
-                            "type": "wpimath.geometry.Rotation3d"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "wheelPositions",
-                            "type": "Tuple[wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition]"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "pose",
-                            "type": "wpimath.geometry.Pose3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive4Odometry3dBase",
-                    "functionName": "resetPosition",
-                    "returnType": "None",
-                    "tooltip": "Resets the robot's position on the field.\n\nThe gyroscope angle does not need to be reset here on the user's robot\ncode. The library automatically takes care of offsetting the gyro angle.\n\n:param gyroAngle:      The angle reported by the gyroscope.\n:param wheelPositions: The current distances measured by each wheel.\n:param pose:           The position on the field that your robot is at."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.SwerveDrive4Odometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "rotation",
-                            "type": "wpimath.geometry.Rotation3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive4Odometry3dBase",
-                    "functionName": "resetRotation",
-                    "returnType": "None",
-                    "tooltip": "Resets the rotation of the pose.\n\n:param rotation: The rotation to reset to."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.SwerveDrive4Odometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "translation",
-                            "type": "wpimath.geometry.Translation3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive4Odometry3dBase",
-                    "functionName": "resetTranslation",
-                    "returnType": "None",
-                    "tooltip": "Resets the translation of the pose.\n\n:param translation: The translation to reset to."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.SwerveDrive4Odometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "gyroAngle",
-                            "type": "wpimath.geometry.Rotation3d"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "wheelPositions",
-                            "type": "Tuple[wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition]"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive4Odometry3dBase",
-                    "functionName": "update",
-                    "returnType": "wpimath.geometry.Pose3d",
-                    "tooltip": "Updates the robot's position on the field using forward kinematics and\nintegration of the pose over time. This method takes in an angle parameter\nwhich is used instead of the angular rate that is calculated from forward\nkinematics, in addition to the current distance measurement at each wheel.\n\n:param gyroAngle:      The angle reported by the gyroscope.\n:param wheelPositions: The current distances measured by each wheel.\n\n:returns: The new pose of the robot."
-                }
-            ],
-            "instanceVariables": [],
-            "moduleName": "wpimath.kinematics",
-            "staticMethods": []
-        },
-        {
-            "className": "wpimath.kinematics.SwerveDrive4Odometry3dBase",
-            "classVariables": [],
-            "constructors": [
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "kinematics",
-                            "type": "wpimath.kinematics.SwerveDrive4KinematicsBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "gyroAngle",
-                            "type": "wpimath.geometry.Rotation3d"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "wheelPositions",
-                            "type": "Tuple[wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition]"
-                        },
-                        {
-                            "defaultValue": "Pose3d(Translation3d(x=0.000000, y=0.000000, z=0.000000), Rotation3d(x=0.000000, y=0.000000, z=0.000000))",
-                            "name": "initialPose",
-                            "type": "wpimath.geometry.Pose3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive4Odometry3dBase",
-                    "functionName": "__init__",
-                    "returnType": "wpimath.kinematics.SwerveDrive4Odometry3dBase",
-                    "tooltip": "Constructs an Odometry3d object.\n\n:param kinematics:     The kinematics for your drivetrain.\n:param gyroAngle:      The angle reported by the gyroscope.\n:param wheelPositions: The current distances measured by each wheel.\n:param initialPose:    The starting position of the robot on the field."
-                }
-            ],
-            "enums": [],
-            "instanceMethods": [
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.SwerveDrive4Odometry3dBase"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive4Odometry3dBase",
-                    "functionName": "getPose",
-                    "returnType": "wpimath.geometry.Pose3d",
-                    "tooltip": "Returns the position of the robot on the field.\n\n:returns: The pose of the robot."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.SwerveDrive4Odometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "pose",
-                            "type": "wpimath.geometry.Pose3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive4Odometry3dBase",
-                    "functionName": "resetPose",
-                    "returnType": "None",
-                    "tooltip": "Resets the pose.\n\n:param pose: The pose to reset to."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.SwerveDrive4Odometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "gyroAngle",
-                            "type": "wpimath.geometry.Rotation3d"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "wheelPositions",
-                            "type": "Tuple[wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition]"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "pose",
-                            "type": "wpimath.geometry.Pose3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive4Odometry3dBase",
-                    "functionName": "resetPosition",
-                    "returnType": "None",
-                    "tooltip": "Resets the robot's position on the field.\n\nThe gyroscope angle does not need to be reset here on the user's robot\ncode. The library automatically takes care of offsetting the gyro angle.\n\n:param gyroAngle:      The angle reported by the gyroscope.\n:param wheelPositions: The current distances measured by each wheel.\n:param pose:           The position on the field that your robot is at."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.SwerveDrive4Odometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "rotation",
-                            "type": "wpimath.geometry.Rotation3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive4Odometry3dBase",
-                    "functionName": "resetRotation",
-                    "returnType": "None",
-                    "tooltip": "Resets the rotation of the pose.\n\n:param rotation: The rotation to reset to."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.SwerveDrive4Odometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "translation",
-                            "type": "wpimath.geometry.Translation3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive4Odometry3dBase",
-                    "functionName": "resetTranslation",
-                    "returnType": "None",
-                    "tooltip": "Resets the translation of the pose.\n\n:param translation: The translation to reset to."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.SwerveDrive4Odometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "gyroAngle",
-                            "type": "wpimath.geometry.Rotation3d"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "wheelPositions",
-                            "type": "Tuple[wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition]"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive4Odometry3dBase",
-                    "functionName": "update",
-                    "returnType": "wpimath.geometry.Pose3d",
                     "tooltip": "Updates the robot's position on the field using forward kinematics and\nintegration of the pose over time. This method takes in an angle parameter\nwhich is used instead of the angular rate that is calculated from forward\nkinematics, in addition to the current distance measurement at each wheel.\n\n:param gyroAngle:      The angle reported by the gyroscope.\n:param wheelPositions: The current distances measured by each wheel.\n\n:returns: The new pose of the robot."
                 }
             ],
@@ -73218,322 +72240,6 @@
                     "declaringClassName": "wpimath.kinematics.SwerveDrive6OdometryBase",
                     "functionName": "update",
                     "returnType": "wpimath.geometry.Pose2d",
-                    "tooltip": "Updates the robot's position on the field using forward kinematics and\nintegration of the pose over time. This method takes in an angle parameter\nwhich is used instead of the angular rate that is calculated from forward\nkinematics, in addition to the current distance measurement at each wheel.\n\n:param gyroAngle:      The angle reported by the gyroscope.\n:param wheelPositions: The current distances measured by each wheel.\n\n:returns: The new pose of the robot."
-                }
-            ],
-            "instanceVariables": [],
-            "moduleName": "wpimath.kinematics",
-            "staticMethods": []
-        },
-        {
-            "className": "wpimath.kinematics.SwerveDrive6Odometry3d",
-            "classVariables": [],
-            "constructors": [
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "kinematics",
-                            "type": "wpimath.kinematics.SwerveDrive6Kinematics"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "gyroAngle",
-                            "type": "wpimath.geometry.Rotation3d"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "modulePositions",
-                            "type": "Tuple[wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition]"
-                        },
-                        {
-                            "defaultValue": "Pose3d(Translation3d(x=0.000000, y=0.000000, z=0.000000), Rotation3d(x=0.000000, y=0.000000, z=0.000000))",
-                            "name": "initialPose",
-                            "type": "wpimath.geometry.Pose3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive6Odometry3d",
-                    "functionName": "__init__",
-                    "returnType": "wpimath.kinematics.SwerveDrive6Odometry3d",
-                    "tooltip": ""
-                }
-            ],
-            "enums": [],
-            "instanceMethods": [
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.SwerveDrive6Odometry3dBase"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive6Odometry3dBase",
-                    "functionName": "getPose",
-                    "returnType": "wpimath.geometry.Pose3d",
-                    "tooltip": "Returns the position of the robot on the field.\n\n:returns: The pose of the robot."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.SwerveDrive6Odometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "pose",
-                            "type": "wpimath.geometry.Pose3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive6Odometry3dBase",
-                    "functionName": "resetPose",
-                    "returnType": "None",
-                    "tooltip": "Resets the pose.\n\n:param pose: The pose to reset to."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.SwerveDrive6Odometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "gyroAngle",
-                            "type": "wpimath.geometry.Rotation3d"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "wheelPositions",
-                            "type": "Tuple[wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition]"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "pose",
-                            "type": "wpimath.geometry.Pose3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive6Odometry3dBase",
-                    "functionName": "resetPosition",
-                    "returnType": "None",
-                    "tooltip": "Resets the robot's position on the field.\n\nThe gyroscope angle does not need to be reset here on the user's robot\ncode. The library automatically takes care of offsetting the gyro angle.\n\n:param gyroAngle:      The angle reported by the gyroscope.\n:param wheelPositions: The current distances measured by each wheel.\n:param pose:           The position on the field that your robot is at."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.SwerveDrive6Odometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "rotation",
-                            "type": "wpimath.geometry.Rotation3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive6Odometry3dBase",
-                    "functionName": "resetRotation",
-                    "returnType": "None",
-                    "tooltip": "Resets the rotation of the pose.\n\n:param rotation: The rotation to reset to."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.SwerveDrive6Odometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "translation",
-                            "type": "wpimath.geometry.Translation3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive6Odometry3dBase",
-                    "functionName": "resetTranslation",
-                    "returnType": "None",
-                    "tooltip": "Resets the translation of the pose.\n\n:param translation: The translation to reset to."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.SwerveDrive6Odometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "gyroAngle",
-                            "type": "wpimath.geometry.Rotation3d"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "wheelPositions",
-                            "type": "Tuple[wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition]"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive6Odometry3dBase",
-                    "functionName": "update",
-                    "returnType": "wpimath.geometry.Pose3d",
-                    "tooltip": "Updates the robot's position on the field using forward kinematics and\nintegration of the pose over time. This method takes in an angle parameter\nwhich is used instead of the angular rate that is calculated from forward\nkinematics, in addition to the current distance measurement at each wheel.\n\n:param gyroAngle:      The angle reported by the gyroscope.\n:param wheelPositions: The current distances measured by each wheel.\n\n:returns: The new pose of the robot."
-                }
-            ],
-            "instanceVariables": [],
-            "moduleName": "wpimath.kinematics",
-            "staticMethods": []
-        },
-        {
-            "className": "wpimath.kinematics.SwerveDrive6Odometry3dBase",
-            "classVariables": [],
-            "constructors": [
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "kinematics",
-                            "type": "wpimath.kinematics.SwerveDrive6KinematicsBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "gyroAngle",
-                            "type": "wpimath.geometry.Rotation3d"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "wheelPositions",
-                            "type": "Tuple[wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition]"
-                        },
-                        {
-                            "defaultValue": "Pose3d(Translation3d(x=0.000000, y=0.000000, z=0.000000), Rotation3d(x=0.000000, y=0.000000, z=0.000000))",
-                            "name": "initialPose",
-                            "type": "wpimath.geometry.Pose3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive6Odometry3dBase",
-                    "functionName": "__init__",
-                    "returnType": "wpimath.kinematics.SwerveDrive6Odometry3dBase",
-                    "tooltip": "Constructs an Odometry3d object.\n\n:param kinematics:     The kinematics for your drivetrain.\n:param gyroAngle:      The angle reported by the gyroscope.\n:param wheelPositions: The current distances measured by each wheel.\n:param initialPose:    The starting position of the robot on the field."
-                }
-            ],
-            "enums": [],
-            "instanceMethods": [
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.SwerveDrive6Odometry3dBase"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive6Odometry3dBase",
-                    "functionName": "getPose",
-                    "returnType": "wpimath.geometry.Pose3d",
-                    "tooltip": "Returns the position of the robot on the field.\n\n:returns: The pose of the robot."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.SwerveDrive6Odometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "pose",
-                            "type": "wpimath.geometry.Pose3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive6Odometry3dBase",
-                    "functionName": "resetPose",
-                    "returnType": "None",
-                    "tooltip": "Resets the pose.\n\n:param pose: The pose to reset to."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.SwerveDrive6Odometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "gyroAngle",
-                            "type": "wpimath.geometry.Rotation3d"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "wheelPositions",
-                            "type": "Tuple[wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition]"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "pose",
-                            "type": "wpimath.geometry.Pose3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive6Odometry3dBase",
-                    "functionName": "resetPosition",
-                    "returnType": "None",
-                    "tooltip": "Resets the robot's position on the field.\n\nThe gyroscope angle does not need to be reset here on the user's robot\ncode. The library automatically takes care of offsetting the gyro angle.\n\n:param gyroAngle:      The angle reported by the gyroscope.\n:param wheelPositions: The current distances measured by each wheel.\n:param pose:           The position on the field that your robot is at."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.SwerveDrive6Odometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "rotation",
-                            "type": "wpimath.geometry.Rotation3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive6Odometry3dBase",
-                    "functionName": "resetRotation",
-                    "returnType": "None",
-                    "tooltip": "Resets the rotation of the pose.\n\n:param rotation: The rotation to reset to."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.SwerveDrive6Odometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "translation",
-                            "type": "wpimath.geometry.Translation3d"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive6Odometry3dBase",
-                    "functionName": "resetTranslation",
-                    "returnType": "None",
-                    "tooltip": "Resets the translation of the pose.\n\n:param translation: The translation to reset to."
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "wpimath.kinematics.SwerveDrive6Odometry3dBase"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "gyroAngle",
-                            "type": "wpimath.geometry.Rotation3d"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "wheelPositions",
-                            "type": "Tuple[wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition, wpimath.kinematics.SwerveModulePosition]"
-                        }
-                    ],
-                    "declaringClassName": "wpimath.kinematics.SwerveDrive6Odometry3dBase",
-                    "functionName": "update",
-                    "returnType": "wpimath.geometry.Pose3d",
                     "tooltip": "Updates the robot's position on the field using forward kinematics and\nintegration of the pose over time. This method takes in an angle parameter\nwhich is used instead of the angular rate that is calculated from forward\nkinematics, in addition to the current distance measurement at each wheel.\n\n:param gyroAngle:      The angle reported by the gyroscope.\n:param wheelPositions: The current distances measured by each wheel.\n\n:returns: The new pose of the robot."
                 }
             ],
@@ -82746,6 +81452,12 @@
     "modules": [
         {
             "enums": [],
+            "functions": [],
+            "moduleName": "expansion_hub",
+            "moduleVariables": []
+        },
+        {
+            "enums": [],
             "functions": [
                 {
                     "args": [],
@@ -82918,7 +81630,7 @@
                         {
                             "defaultValue": "",
                             "name": "type",
-                            "type": "hal.RuntimeType"
+                            "type": "hal._wpiHal.RuntimeType"
                         }
                     ],
                     "functionName": "setRuntimeType",
@@ -83437,15 +82149,15 @@
         }
     ],
     "subclasses": {
-        "hal.AddressableLEDData": [
+        "hal._wpiHal.AddressableLEDData": [
             "wpilib.AddressableLED.LEDData"
         ],
-        "hal.SimValue": [
-            "hal.SimBoolean",
-            "hal.SimDouble",
-            "hal.SimEnum",
-            "hal.SimInt",
-            "hal.SimLong"
+        "hal._wpiHal.SimValue": [
+            "hal._wpiHal.SimBoolean",
+            "hal._wpiHal.SimDouble",
+            "hal._wpiHal.SimEnum",
+            "hal._wpiHal.SimInt",
+            "hal._wpiHal.SimLong"
         ],
         "ntcore.BooleanArrayPublisher": [
             "ntcore.BooleanArrayEntry"
@@ -83705,17 +82417,11 @@
         "wpimath.kinematics.DifferentialDriveKinematicsBase": [
             "wpimath.kinematics.DifferentialDriveKinematics"
         ],
-        "wpimath.kinematics.DifferentialDriveOdometry3dBase": [
-            "wpimath.kinematics.DifferentialDriveOdometry3d"
-        ],
         "wpimath.kinematics.DifferentialDriveOdometryBase": [
             "wpimath.kinematics.DifferentialDriveOdometry"
         ],
         "wpimath.kinematics.MecanumDriveKinematicsBase": [
             "wpimath.kinematics.MecanumDriveKinematics"
-        ],
-        "wpimath.kinematics.MecanumDriveOdometry3dBase": [
-            "wpimath.kinematics.MecanumDriveOdometry3d"
         ],
         "wpimath.kinematics.MecanumDriveOdometryBase": [
             "wpimath.kinematics.MecanumDriveOdometry"
@@ -83723,17 +82429,11 @@
         "wpimath.kinematics.SwerveDrive2KinematicsBase": [
             "wpimath.kinematics.SwerveDrive2Kinematics"
         ],
-        "wpimath.kinematics.SwerveDrive2Odometry3dBase": [
-            "wpimath.kinematics.SwerveDrive2Odometry3d"
-        ],
         "wpimath.kinematics.SwerveDrive2OdometryBase": [
             "wpimath.kinematics.SwerveDrive2Odometry"
         ],
         "wpimath.kinematics.SwerveDrive3KinematicsBase": [
             "wpimath.kinematics.SwerveDrive3Kinematics"
-        ],
-        "wpimath.kinematics.SwerveDrive3Odometry3dBase": [
-            "wpimath.kinematics.SwerveDrive3Odometry3d"
         ],
         "wpimath.kinematics.SwerveDrive3OdometryBase": [
             "wpimath.kinematics.SwerveDrive3Odometry"
@@ -83741,20 +82441,32 @@
         "wpimath.kinematics.SwerveDrive4KinematicsBase": [
             "wpimath.kinematics.SwerveDrive4Kinematics"
         ],
-        "wpimath.kinematics.SwerveDrive4Odometry3dBase": [
-            "wpimath.kinematics.SwerveDrive4Odometry3d"
-        ],
         "wpimath.kinematics.SwerveDrive4OdometryBase": [
             "wpimath.kinematics.SwerveDrive4Odometry"
         ],
         "wpimath.kinematics.SwerveDrive6KinematicsBase": [
             "wpimath.kinematics.SwerveDrive6Kinematics"
         ],
-        "wpimath.kinematics.SwerveDrive6Odometry3dBase": [
-            "wpimath.kinematics.SwerveDrive6Odometry3d"
-        ],
         "wpimath.kinematics.SwerveDrive6OdometryBase": [
             "wpimath.kinematics.SwerveDrive6Odometry"
+        ],
+        "wpimath.kinematics._kinematics.DifferentialDriveOdometry3dBase": [
+            "wpimath.kinematics._kinematics.DifferentialDriveOdometry3d"
+        ],
+        "wpimath.kinematics._kinematics.MecanumDriveOdometry3dBase": [
+            "wpimath.kinematics._kinematics.MecanumDriveOdometry3d"
+        ],
+        "wpimath.kinematics._kinematics.SwerveDrive2Odometry3dBase": [
+            "wpimath.kinematics._kinematics.SwerveDrive2Odometry3d"
+        ],
+        "wpimath.kinematics._kinematics.SwerveDrive3Odometry3dBase": [
+            "wpimath.kinematics._kinematics.SwerveDrive3Odometry3d"
+        ],
+        "wpimath.kinematics._kinematics.SwerveDrive4Odometry3dBase": [
+            "wpimath.kinematics._kinematics.SwerveDrive4Odometry3d"
+        ],
+        "wpimath.kinematics._kinematics.SwerveDrive6Odometry3dBase": [
+            "wpimath.kinematics._kinematics.SwerveDrive6Odometry3d"
         ],
         "wpimath.spline.Spline3": [
             "wpimath.spline.CubicHermiteSpline"

--- a/src/blocks/utils/generated/server_python_scripts.json
+++ b/src/blocks/utils/generated/server_python_scripts.json
@@ -261,19 +261,19 @@
         {
             "enums": [],
             "functions": [],
-            "moduleName": "blocks_base_classes",
+            "moduleName": "blocks_base_classes.mechanism",
             "moduleVariables": []
         },
         {
             "enums": [],
             "functions": [],
-            "moduleName": "blocks_base_classes",
+            "moduleName": "blocks_base_classes.opmode",
             "moduleVariables": []
         },
         {
             "enums": [],
             "functions": [],
-            "moduleName": "blocks_base_classes",
+            "moduleName": "blocks_base_classes.robot_base",
             "moduleVariables": []
         }
     ],


### PR DESCRIPTION
Add expansion hub python code.

Improved python tools:
Removed _DICT_FULL_MODULE_NAME_TO_MODULE_NAME. Use <module>.__all__ instead.
Pass the json_generator_robotpy to the constructor for json_generator_external_samples so it can understand the module exports from robotpy.

Renamed SparkMiniComponent to SparkMini.
