### PR TITLE
Make RobotBase.__init__ call self.define_hardware()

### DIFF
--- a/server_python_scripts/blocks_base_classes/robot_base.py
+++ b/server_python_scripts/blocks_base_classes/robot_base.py
@@ -7,6 +7,10 @@ class RobotBase:
         self.hardware = []
         # In self.event_handlers, the keys are the event names, the values are a list of handlers.
         self.event_handlers = {}
+        self.define_hardware()
+
+    def define_hardware(self):
+        pass
 
     def register_event_handler(self, event_name: str, event_handler: Callable) -> None:
         if event_name in self.event_handlers:

--- a/src/blocks/mrc_mechanism_component_holder.ts
+++ b/src/blocks/mrc_mechanism_component_holder.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  * Copyright 2025 Porpoiseful LLC
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -64,7 +64,7 @@ function setName(block: Blockly.BlockSvg){
                 otherNames.push(variableBlock.getFieldValue('NAME'));
             }
         });
-        const currentName = block.getFieldValue('NAME');       
+        const currentName = block.getFieldValue('NAME');
         block.setFieldValue(getLegalName(currentName, otherNames), 'NAME');
     }
 }
@@ -205,8 +205,8 @@ function pythonFromBlockInRobot(block: MechanismComponentHolderBlock, generator:
   const body = mechanisms + components;
   if (body != '') {
     code += body;
-    generator.addClassMethodDefinition('define_hardware', code);    
-  } 
+    generator.addClassMethodDefinition('define_hardware', code);
+  }
 }
 
 function pythonFromBlockInMechanism(block: MechanismComponentHolderBlock, generator: ExtendedPythonGenerator) {
@@ -218,19 +218,20 @@ function pythonFromBlockInMechanism(block: MechanismComponentHolderBlock, genera
 
   if (components != '') {
     code += components;
-    generator.addClassMethodDefinition('define_hardware', code);    
+    generator.addClassMethodDefinition('define_hardware', code);
   }
 }
 
 export const pythonFromBlock = function (
   block: MechanismComponentHolderBlock,
-  generator: ExtendedPythonGenerator,
-) {
-  if (block.getInput(INPUT_MECHANISMS)) {
-    pythonFromBlockInRobot(block, generator);
-  }
-  else {
-    pythonFromBlockInMechanism(block, generator);
+  generator: ExtendedPythonGenerator) {
+  switch (generator.getModuleType()) {
+    case commonStorage.MODULE_TYPE_ROBOT:
+      pythonFromBlockInRobot(block, generator);
+      break;
+    case commonStorage.MODULE_TYPE_MECHANISM:
+      pythonFromBlockInMechanism(block, generator);
+      break;
   }
   return ''
 }


### PR DESCRIPTION
Add define_hardware method to RobotBase and call it from RobotBase.__init__.

Modified mrc_mechanism_component_holder pythonFromBlock to determine the module type by calling generator.getModuleType() instead of checking for the presence of the mechanisms input.

Modified ExtendedPythonGenerator.generateInitStatements to not generate the call so self.define_hardware() if the module type is robot.

Modified ExtendedPythonGenerator.finish to generate the __init__ method before other methods.