### PR TITLE
Don’t allow 2 event handlers for the same event in the same module

### DIFF
--- a/src/blocks/mrc_event.ts
+++ b/src/blocks/mrc_event.ts
@@ -238,11 +238,11 @@ export const pythonFromBlock = function (
 
 // Functions used for creating blocks for the toolbox.
 
-export function createCustomEventBlock(): toolboxItems.Block {
+export function createCustomEventBlock(name: string): toolboxItems.Block {
   const extraState: EventExtraState = {
     params: [],
   };
   const fields: {[key: string]: any} = {};
-  fields[FIELD_EVENT_NAME] = 'my_event';
+  fields[FIELD_EVENT_NAME] = name;
   return new toolboxItems.Block(BLOCK_NAME, extraState, fields, null);
 }

--- a/src/blocks/mrc_event_handler.ts
+++ b/src/blocks/mrc_event_handler.ts
@@ -226,9 +226,6 @@ export function pythonFromBlock(
   const blocklyName = `${sender}_${eventName}`;
   const funcName = generator.getProcedureName(blocklyName);
 
-  // TODO(lizlooney): if the user adds multiple event handlers for the same event
-  // name, we need to make the event handler function names unique.
-
   let xfix1 = '';
   if (generator.STATEMENT_PREFIX) {
     xfix1 += generator.injectId(generator.STATEMENT_PREFIX, block);
@@ -323,8 +320,16 @@ function createRobotEventHandlerBlock(
 
 // Misc
 
-export function getHasEventHandler(workspace: Blockly.Workspace): boolean {
+export function getHasAnyEnabledEventHandlers(workspace: Blockly.Workspace): boolean {
   return workspace.getBlocksByType(BLOCK_NAME).filter(block => {
     return block.isEnabled();
   }).length > 0;
+}
+
+export function getEventHandlerNames(workspace: Blockly.Workspace, names: string[]): void {
+  // Here we collect the event names of the event handlers in the given
+  // workspace, regardless of whether the event handler is enabled.
+  workspace.getBlocksByType(BLOCK_NAME).forEach(block => {
+    names.push(block.getFieldValue(FIELD_EVENT_NAME));
+  });
 }

--- a/src/editor/extended_python_generator.ts
+++ b/src/editor/extended_python_generator.ts
@@ -134,7 +134,7 @@ export class ExtendedPythonGenerator extends PythonGenerator {
 
     this.ports = Object.create(null);
     this.hasHardware = mechanismContainerHolder.getHardwarePorts(this.workspace, this.ports);
-    this.hasEventHandler = eventHandler.getHasEventHandler(this.workspace);
+    this.hasEventHandler = eventHandler.getHasAnyEnabledEventHandlers(this.workspace);
 
     const code = super.workspaceToCode(workspace);
 

--- a/src/storage/common_storage.ts
+++ b/src/storage/common_storage.ts
@@ -629,25 +629,10 @@ export function getClassNameForModule(moduleType: string, moduleName: string) {
  * Make a unique project name for an uploaded project.
  */
 export function makeUploadProjectName(
-  uploadFileName: string, existingProjectNames: string[]): string {
+    uploadFileName: string, existingProjectNames: string[]): string {
   const preferredName = uploadFileName.substring(
     0, uploadFileName.length - UPLOAD_DOWNLOAD_FILE_EXTENSION.length);
-  let name = preferredName; // No suffix.
-  let suffix = 0;
-  while (true) {
-    let nameClash = false;
-    for (const existingProjectName of existingProjectNames) {
-      if (name == existingProjectName) {
-        nameClash = true;
-        break;
-      }
-    }
-    if (!nameClash) {
-      return name;
-    }
-    suffix++;
-    name = preferredName + suffix;
-  }
+  return makeUniqueName(preferredName, existingProjectNames);
 }
 
 /**
@@ -703,4 +688,26 @@ export function _processUploadedModule(
   const moduleName = (moduleType === MODULE_TYPE_ROBOT) ? 'robot' : filename;
   const moduleContentText = moduleContent.getModuleContentText();
   return [moduleName, moduleType, moduleContentText];
+}
+
+/**
+ * Makes a unique name given a list of existing names
+ */
+export function makeUniqueName(preferredName: string, existingNames: string[]): string {
+  let name = preferredName; // No suffix.
+  let suffix = 0;
+  while (true) {
+    let nameClash = false;
+    for (const existingName of existingNames) {
+      if (name == existingName) {
+        nameClash = true;
+        break;
+      }
+    }
+    if (!nameClash) {
+      return name;
+    }
+    suffix++;
+    name = preferredName + suffix;
+  }
 }

--- a/src/toolbox/event_category.ts
+++ b/src/toolbox/event_category.ts
@@ -38,32 +38,31 @@ export const getCategory = () => ({
 });
 
 export class EventsCategory {
-  private currentModule: commonStorage.Module | null = null;
-
   constructor(blocklyWorkspace: Blockly.WorkspaceSvg) {
     blocklyWorkspace.registerToolboxCategoryCallback(CUSTOM_CATEGORY_EVENTS, this.eventsFlyout.bind(this));
-  }
-
-  public setCurrentModule(currentModule: commonStorage.Module | null) {
-    this.currentModule = currentModule;
   }
 
   public eventsFlyout(workspace: Blockly.WorkspaceSvg) {
     const contents: toolboxItems.ContentsType[] = [];
 
-    // Add a block that lets the user define a new event.
-    contents.push(
-      {
-        kind: 'label',
-        text: 'Custom Events',
-      },
-      createCustomEventBlock()
-    );
-
-    // Get blocks for firing methods defined in the current workspace.
     const editor = Editor.getEditorForBlocklyWorkspace(workspace);
     if (editor) {
       const eventsFromWorkspace = editor.getEventsFromWorkspace();
+      const eventNames: string[] = [];
+      eventsFromWorkspace.forEach(event => {
+        eventNames.push(event.name);
+      });
+
+      // Add a block that lets the user define a new event.
+      contents.push(
+        {
+          kind: 'label',
+          text: 'Custom Events',
+        },
+        createCustomEventBlock(commonStorage.makeUniqueName('my_event', eventNames))
+      );
+
+      // Get blocks for firing methods defined in the current workspace.
       addFireEventBlocks(eventsFromWorkspace, contents);
     }
 

--- a/src/toolbox/methods_category.ts
+++ b/src/toolbox/methods_category.ts
@@ -40,17 +40,12 @@ export const getCategory = () => ({
 });
 
 export class MethodsCategory {
-  private currentModule: commonStorage.Module | null = null;
   private robotClassBlocks = getBaseClassBlocks(CLASS_NAME_ROBOT_BASE);
   private mechanismClassBlocks = getBaseClassBlocks(CLASS_NAME_MECHANISM);
   private opmodeClassBlocks = getBaseClassBlocks(CLASS_NAME_OPMODE);
 
   constructor(blocklyWorkspace: Blockly.WorkspaceSvg) {
     blocklyWorkspace.registerToolboxCategoryCallback(CUSTOM_CATEGORY_METHODS, this.methodsFlyout.bind(this));
-  }
-
-  public setCurrentModule(currentModule: commonStorage.Module | null) {
-    this.currentModule = currentModule;
   }
 
   public methodsFlyout(workspace: Blockly.WorkspaceSvg) {
@@ -65,8 +60,8 @@ export class MethodsCategory {
       // Collect the method names that are already overridden in the blockly workspace.
       const methodNamesAlreadyOverridden = editor.getMethodNamesAlreadyOverriddenInWorkspace();
 
-      if (this.currentModule) {
-        if (this.currentModule.moduleType == commonStorage.MODULE_TYPE_ROBOT) {
+      switch (editor.getCurrentModuleType()) {
+        case commonStorage.MODULE_TYPE_ROBOT:
           // TODO(lizlooney): We need a way to mark a method in python as not overridable.
           // For example, in RobotBase, register_event_handler, unregister_event_handler,
           // and fire_event should not be overridden in a user's robot.
@@ -79,17 +74,19 @@ export class MethodsCategory {
           this.addClassBlocksForCurrentModule(
               'More Robot Methods', this.robotClassBlocks, methodNamesNotOverrideable,
               methodNamesAlreadyOverridden, contents);
-        } else if (this.currentModule.moduleType == commonStorage.MODULE_TYPE_MECHANISM) {
+          break;
+        case commonStorage.MODULE_TYPE_MECHANISM:
           // Add the methods for a Mechanism.
           this.addClassBlocksForCurrentModule(
               'More Mechanism Methods', this.mechanismClassBlocks, [],
               methodNamesAlreadyOverridden, contents);
-        } else if (this.currentModule.moduleType == commonStorage.MODULE_TYPE_OPMODE) {
+          break;
+        case commonStorage.MODULE_TYPE_OPMODE:
           // Add the methods for an OpMode.
           this.addClassBlocksForCurrentModule(
               'More OpMode Methods', this.opmodeClassBlocks, [],
               methodNamesAlreadyOverridden, contents);
-        }
+          break;
       }
     }
 


### PR DESCRIPTION
In common_storage.ts, added function makeUniqueName. Modified makeUploadProjectName to call makeUniqueName.

In editor.ts, added methods getCurrentModuleType and getEventHandlerNames. Removed fields methodsCategory and eventsCategory, but still create all custom toolbox categories in the constructor.

In mrc_event_handler.ts, renamed function getHasEventHandler to getHasAnyEnabledEventHandlers. Added function getEventHandlerNames.

In mrc_event.ts, modified createCustomEventBlock to take the event name as a parameter.

In hardware_category.ts, renamed functions that return a category to be named get...Category instead of get...Blocks. Make RobotEventsCategory a custom category with a flyout callback.

In event_category, removed field currentModule and method setCurrentModule. Make a unique name for creating a new event.

In methods_category, removed field currentModule and method setCurrentModule. Use editor.getCurrentModuleType() instead.