### PR TITLE
Call blocklyWorkspace.dispose() after toolbox tests are finished.

### DIFF
--- a/src/toolbox/toolbox_tests.ts
+++ b/src/toolbox/toolbox_tests.ts
@@ -95,6 +95,7 @@ class ToolboxTestData {
     if (this.index < this.jsonBlocks.length) {
       setTimeout(this.testCallback.bind(this), 0);
     } else {
+      this.blocklyWorkspace.dispose();
       if (this.onFinish) {
         this.onFinish();
       }


### PR DESCRIPTION
Call blocklyWorkspace.dispose() after toolbox tests are finished.