### PR TITLE
Share VariableKind enum for get and set python variable blocks

### DIFF
--- a/src/blocks/mrc_get_python_variable.ts
+++ b/src/blocks/mrc_get_python_variable.ts
@@ -40,7 +40,7 @@ import * as toolboxItems from '../toolbox/items';
 
 export const BLOCK_NAME = 'mrc_get_python_variable';
 
-enum VariableKind {
+export enum VariableKind {
   MODULE = 'module',
   CLASS = 'class',
   INSTANCE = 'instance',

--- a/src/blocks/mrc_set_python_variable.ts
+++ b/src/blocks/mrc_set_python_variable.ts
@@ -23,6 +23,7 @@
 import * as Blockly from 'blockly';
 import { Order } from 'blockly/python';
 
+import { VariableKind } from './mrc_get_python_variable';
 import { getAllowedTypesForSetCheck } from './utils/python';
 import * as variable from './utils/variable';
 import { ExtendedPythonGenerator } from '../editor/extended_python_generator';
@@ -35,14 +36,6 @@ import * as toolboxItems from '../toolbox/items';
 // A block to set a python variable.
 
 export const BLOCK_NAME = 'mrc_set_python_variable';
-
-// TODO(lizlooney): Consider combining VariableKind here with VariableKind in
-// mrc_get_python_variable.ts. They are identical.
-enum VariableKind {
-  MODULE = 'module',
-  CLASS = 'class',
-  INSTANCE = 'instance',
-}
 
 const FIELD_MODULE_OR_CLASS_NAME = 'MODULE_OR_CLASS';
 const FIELD_VARIABLE_NAME = 'VAR';


### PR DESCRIPTION
Share VariableKind enum for get and set python variable blocks.

Remove VariableKind in mrc_set_python_variable.ts.
Use VariableKind from mrc_get_python_variable.ts.