### PR TITLE
Changed opmode details back to being editable

### DIFF
--- a/src/modules/opmode_start.json
+++ b/src/modules/opmode_start.json
@@ -7,7 +7,7 @@
                 "x": 10,
                 "y": 10,
                 "deletable": false,
-                "editable": false,
+                "editable": true,
                 "fields": {
                     "TYPE": "Teleop",
                     "ENABLED": true,


### PR DESCRIPTION
I went to go see why we weren't able to change the opmode type and it turns out that it accidentally had "editable" set to false in the default set of blocks for an opmode.   This changes it back.
