### PR TITLE
Make necessary changes to blocks when changing tabs

### DIFF
--- a/src/blocks/mrc_call_python_function.ts
+++ b/src/blocks/mrc_call_python_function.ts
@@ -318,7 +318,7 @@ const CALL_PYTHON_FUNCTION = {
     this.mrcMechanismId = extraState.mechanismId ? extraState.mechanismId : '';
     this.mrcComponentClassName = extraState.componentClassName ? extraState.componentClassName : '';
     this.mrcMechanismClassName = extraState.mechanismClassName ? extraState.mechanismClassName : '';
-    // Initialize mrcComponentNames and mrcMapComponentNameToId here. They will be filled during mrcOnLoad.
+    // Initialize mrcComponentNames and mrcMapComponentNameToId here. They will be filled during mrcValidate.
     this.mrcComponentNames = [];
     this.mrcMapComponentNameToId = {};
     this.updateBlock_();
@@ -405,7 +405,7 @@ const CALL_PYTHON_FUNCTION = {
                 .appendField('.');
           }
           // Here we create a text field for the component name.
-          // Later, in mrcOnLoad, we will replace it with a dropdown.
+          // Later, in mrcValidate, we will replace it with a dropdown.
           titleInput
               .appendField(createFieldNonEditableText(''), FIELD_COMPONENT_NAME)
               .appendField('.')
@@ -565,8 +565,18 @@ const CALL_PYTHON_FUNCTION = {
     }
     return components;
   },
+  /**
+   * mrcOnLoad is called for each CallPythonFunctionBlock when the blocks are loaded in the blockly
+   * workspace.
+   */
   mrcOnLoad: function(this: CallPythonFunctionBlock): void {
-    // mrcOnLoad is called for each CallPythonFunctionBlock when the blocks are loaded in the blockly workspace.
+    this.mrcValidate();
+  },
+  /**
+   * mrcValidate checks the block, updates it, and/or adds a warning balloon if necessary.
+   * It is called from mrcOnLoad above and from Editor.makeCurrent.
+   */
+  mrcValidate: function(this: CallPythonFunctionBlock): void {
     const editor = Editor.getEditorForBlocklyWorkspace(this.workspace, true /* returnCurrentIfNotFound */);
     if (!editor) {
       return;

--- a/src/blocks/mrc_event_handler.ts
+++ b/src/blocks/mrc_event_handler.ts
@@ -176,6 +176,13 @@ const EVENT_HANDLER = {
    * workspace.
    */
   mrcOnLoad: function(this: EventHandlerBlock): void {
+    this.mrcValidate();
+  },
+  /**
+   * mrcValidate checks the block, updates it, and/or adds a warning balloon if necessary.
+   * It is called from mrcOnLoad above and from Editor.makeCurrent.
+   */
+  mrcValidate: function(this: EventHandlerBlock): void {
     const warnings: string[] = [];
 
     const editor = Editor.getEditorForBlocklyWorkspace(this.workspace, true /* returnCurrentIfNotFound */);

--- a/src/blocks/mrc_mechanism.ts
+++ b/src/blocks/mrc_mechanism.ts
@@ -174,8 +174,19 @@ const MECHANISM = {
       className: mechanismType,
     };
   },
+
+  /**
+   * mrcOnLoad is called for each MechanismBlock when the blocks are loaded in the blockly
+   * workspace.
+   */
   mrcOnLoad: function(this: MechanismBlock): void {
-    // mrcOnLoad is called for each MechanismBlock when the blocks are loaded in the blockly workspace.
+    this.mrcValidate();
+  },
+  /**
+   * mrcValidate checks the block, updates it, and/or adds a warning balloon if necessary.
+   * It is called from mrcOnLoad above and from Editor.makeCurrent.
+   */
+  mrcValidate: function(this: MechanismBlock): void {
     const warnings: string[] = [];
 
     const editor = Editor.getEditorForBlocklyWorkspace(this.workspace, true /* returnCurrentIfNotFound */);

--- a/src/editor/editor.ts
+++ b/src/editor/editor.ts
@@ -129,6 +129,13 @@ export class Editor {
     // Parse modules since they might have changed.
     this.parseModules(project, modulePathToContentText);
     this.updateToolboxImpl();
+
+    // Go through all the blocks in the workspace and call their mrcValidate method.
+    this.blocklyWorkspace.getAllBlocks().forEach(block => {
+      if ('mrcValidate' in block && typeof block.mrcValidate === "function") {
+        block.mrcValidate();
+      }
+    });
   }
 
   public abandon(): void {

--- a/src/editor/editor.ts
+++ b/src/editor/editor.ts
@@ -38,6 +38,9 @@ const EMPTY_TOOLBOX: Blockly.utils.toolbox.ToolboxDefinition = {
   contents: [],
 };
 
+const MRC_ON_LOAD = 'mrcOnLoad';
+const MRC_VALIDATE = 'mrcValidate';
+
 export class Editor {
   private static workspaceIdToEditor: { [workspaceId: string]: Editor } = {};
   private static currentEditor: Editor | null = null;
@@ -97,8 +100,8 @@ export class Editor {
         blockCreateEvent.ids.forEach(id => {
           const block = this.blocklyWorkspace.getBlockById(id);
           if (block) {
-            if ('mrcOnLoad' in block && typeof block.mrcOnLoad === "function") {
-              block.mrcOnLoad();
+            if (MRC_ON_LOAD in block && typeof block[MRC_ON_LOAD] === 'function') {
+              block[MRC_ON_LOAD]();
             }
           }
         });
@@ -132,8 +135,8 @@ export class Editor {
 
     // Go through all the blocks in the workspace and call their mrcValidate method.
     this.blocklyWorkspace.getAllBlocks().forEach(block => {
-      if ('mrcValidate' in block && typeof block.mrcValidate === "function") {
-        block.mrcValidate();
+      if (MRC_VALIDATE in block && typeof block[MRC_VALIDATE] === 'function') {
+        block[MRC_VALIDATE]();
       }
     });
   }
@@ -165,8 +168,8 @@ export class Editor {
     for (const mechanism of this.mechanisms) {
       const moduleContent = this.modulePathToModuleContent[mechanism.modulePath];
       if (!moduleContent) {
-        console.error(this.modulePath + " editor.parseModules - modulePathToModuleContent['" +
-            mechanism.modulePath + "'] is undefined");
+        console.error(this.modulePath + ' editor.parseModules - modulePathToModuleContent["' +
+            mechanism.modulePath + '"] is undefined');
         continue;
       }
       this.mechanismClassNameToModuleContent[mechanism.className] = moduleContent;


### PR DESCRIPTION
In blocks that have an mrcOnLoad method, create a method called mrcValidate. Make mrcOnLoad call mrcValidate.

In editor.makeCurrent, call the mrcValidate method on all blocks that implement it.

Fixes #237