### PR TITLE
Allow code panel to be resized

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -79,7 +79,7 @@ const FULL_VIEWPORT_HEIGHT = '100vh';
 const FULL_HEIGHT = '100%';
 
 /** Default size for code panel. */
-const CODE_PANEL_DEFAULT_SIZE = 400;
+const CODE_PANEL_DEFAULT_SIZE = '25%';
 
 /** Minimum size for code panel. */
 const CODE_PANEL_MIN_SIZE = 100;
@@ -167,9 +167,9 @@ const AppContent: React.FC<AppContentProps> = ({ project, setProject }): React.J
   const [shownPythonToolboxCategories, setShownPythonToolboxCategories] = React.useState<Set<string>>(new Set());
   const [triggerPythonRegeneration, setTriggerPythonRegeneration] = React.useState(0);
   const [leftCollapsed, setLeftCollapsed] = React.useState(false);
-  const [codePanelSize, setCodePanelSize] = React.useState<number>(CODE_PANEL_DEFAULT_SIZE);
+  const [codePanelSize, setCodePanelSize] = React.useState<string | number>(CODE_PANEL_DEFAULT_SIZE);
   const [codePanelCollapsed, setCodePanelCollapsed] = React.useState(false);
-  const [codePanelExpandedSize, setCodePanelExpandedSize] = React.useState<number>(CODE_PANEL_DEFAULT_SIZE);
+  const [codePanelExpandedSize, setCodePanelExpandedSize] = React.useState<string | number>(CODE_PANEL_DEFAULT_SIZE);
   const [codePanelAnimating, setCodePanelAnimating] = React.useState(false);
   const [theme, setTheme] = React.useState('dark');
   const [languageInitialized, setLanguageInitialized] = React.useState(false);
@@ -391,8 +391,11 @@ const AppContent: React.FC<AppContentProps> = ({ project, setProject }): React.J
       setCodePanelSize(codePanelExpandedSize);
       setCodePanelCollapsed(false);
     } else {
-      // Collapse to minimum size
-      setCodePanelExpandedSize(codePanelSize);
+      // Collapse to minimum size - convert current size to pixels for storage
+      const currentSizePx = typeof codePanelSize === 'string'
+        ? (parseFloat(codePanelSize) / 100) * window.innerWidth
+        : codePanelSize;
+      setCodePanelExpandedSize(currentSizePx);
       setCodePanelSize(CODE_PANEL_MIN_SIZE);
       setCodePanelCollapsed(true);
     }
@@ -687,7 +690,7 @@ const AppContent: React.FC<AppContentProps> = ({ project, setProject }): React.J
                 </Content>
                 <div
                   style={{
-                    width: `${codePanelSize}px`,
+                    width: typeof codePanelSize === 'string' ? codePanelSize : `${codePanelSize}px`,
                     minWidth: CODE_PANEL_MIN_SIZE,
                     height: '100%',
                     borderLeft: '1px solid #d9d9d9',
@@ -714,7 +717,11 @@ const AppContent: React.FC<AppContentProps> = ({ project, setProject }): React.J
                       
                       const handleMouseMove = (e: MouseEvent) => {
                         const deltaX = startX - e.clientX;
-                        const newWidth = Math.max(CODE_PANEL_MIN_SIZE, startWidth + deltaX);
+                        // Convert startWidth to number if it's a percentage
+                        const startWidthPx = typeof startWidth === 'string' 
+                          ? (parseFloat(startWidth) / 100) * window.innerWidth
+                          : startWidth;
+                        const newWidth = Math.max(CODE_PANEL_MIN_SIZE, startWidthPx + deltaX);
                         setCodePanelSize(newWidth);
                         // Update expanded size if not at minimum
                         if (newWidth > CODE_PANEL_MIN_SIZE) {

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -43,6 +43,8 @@
     "BLOCKS": "Blocks",
     "CODE": "Code",
     "COPY": "Copy",
+    "COLLAPSE": "Collapse",
+    "EXPAND": "Expand",
     "FAILED_TO_RENAME_PROJECT": "Failed to rename project",
     "FAILED_TO_COPY_PROJECT": "Failed to copy project",
     "FAILED_TO_CREATE_PROJECT": "Failed to create a new project.",

--- a/src/i18n/locales/es/translation.json
+++ b/src/i18n/locales/es/translation.json
@@ -40,6 +40,8 @@
     "BLOCKS": "Bloques",
     "CODE": "Código",
     "COPY": "Copiar",
+    "COLLAPSE": "Colapsar",
+    "EXPAND": "Expandir",
     "FAILED_TO_RENAME_PROJECT": "Error al renombrar proyecto",
     "FAILED_TO_COPY_PROJECT": "Error al copiar proyecto",
     "FAILED_TO_CREATE_PROJECT": "Error al crear un nuevo proyecto.",

--- a/src/i18n/locales/he/translation.json
+++ b/src/i18n/locales/he/translation.json
@@ -43,6 +43,8 @@
   "BLOCKS": "בלוקים",
   "CODE": "קוד",
   "COPY": "העתק",
+  "COLLAPSE": "כווץ",
+  "EXPAND": "הרחב",
     "FAILED_TO_RENAME_PROJECT": "נכשל בשינוי שם הפרויקט",
     "FAILED_TO_COPY_PROJECT": "נכשל בהעתקת הפרויקט",
     "FAILED_TO_CREATE_PROJECT": "נכשל ביצירת פרויקט חדש.",

--- a/src/reactComponents/CodeDisplay.tsx
+++ b/src/reactComponents/CodeDisplay.tsx
@@ -20,8 +20,9 @@
  */
 import * as Antd from 'antd';
 import * as React from 'react';
-import { CopyOutlined as CopyIcon, LeftOutlined as CollapseIcon, RightOutlined as ExpandIcon } from '@ant-design/icons';
+import { CopyOutlined as CopyIcon } from '@ant-design/icons';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
+import SiderCollapseTrigger from './SiderCollapseTrigger';
 import { dracula, oneLight } from 'react-syntax-highlighter/dist/esm/styles/prism';
 
 import type { MessageInstance } from 'antd/es/message/interface';
@@ -117,41 +118,10 @@ export default function CodeDisplay(props: CodeDisplayProps): React.JSX.Element 
     if (!props.onToggleCollapse) return null;
     
     return (
-      <div
-        style={{
-          position: 'absolute',
-          bottom: 0,
-          left: '50%',
-          transform: 'translateX(-50%)',
-          backgroundColor: token.colorBgContainer,
-          border: `1px solid ${token.colorBorder}`,
-          borderBottom: 'none',
-          borderRadius: '6px 6px 0 0',
-          padding: '2px 6px',
-          cursor: 'pointer',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          minWidth: '24px',
-          height: '22px',
-          color: token.colorTextSecondary,
-          transition: 'all 0.2s',
-          zIndex: 1,
-        }}
-        onClick={props.onToggleCollapse}
-        onMouseEnter={(e) => {
-          e.currentTarget.style.color = token.colorText;
-          e.currentTarget.style.backgroundColor = token.colorBgTextHover;
-        }}
-        onMouseLeave={(e) => {
-          e.currentTarget.style.color = token.colorTextSecondary;
-          e.currentTarget.style.backgroundColor = token.colorBgContainer;
-        }}
-      >
-        <Antd.Tooltip title={props.isCollapsed ? t("EXPAND") : t("COLLAPSE")}>
-          {props.isCollapsed ? <ExpandIcon /> : <CollapseIcon />}
-        </Antd.Tooltip>
-      </div>
+      <SiderCollapseTrigger
+        collapsed={props.isCollapsed || false}
+        onToggle={props.onToggleCollapse}
+      />
     );
   };
 

--- a/src/reactComponents/CodeDisplay.tsx
+++ b/src/reactComponents/CodeDisplay.tsx
@@ -20,7 +20,7 @@
  */
 import * as Antd from 'antd';
 import * as React from 'react';
-import { CopyOutlined as CopyIcon } from '@ant-design/icons';
+import { CopyOutlined as CopyIcon, LeftOutlined as CollapseIcon, RightOutlined as ExpandIcon } from '@ant-design/icons';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { dracula, oneLight } from 'react-syntax-highlighter/dist/esm/styles/prism';
 
@@ -36,6 +36,8 @@ interface CodeDisplayProps {
   theme: string;
   messageApi: MessageInstance;
   setAlertErrorMessage: StringFunction;
+  isCollapsed?: boolean;
+  onToggleCollapse?: () => void;
 }
 
 /** Success message for copy operation. */
@@ -110,10 +112,56 @@ export default function CodeDisplay(props: CodeDisplayProps): React.JSX.Element 
     </SyntaxHighlighter>
   );
 
+  /** Renders the collapse/expand trigger at the bottom center of the panel. */
+  const renderCollapseTrigger = (): React.JSX.Element | null => {
+    if (!props.onToggleCollapse) return null;
+    
+    return (
+      <div
+        style={{
+          position: 'absolute',
+          bottom: 0,
+          left: '50%',
+          transform: 'translateX(-50%)',
+          backgroundColor: token.colorBgContainer,
+          border: `1px solid ${token.colorBorder}`,
+          borderBottom: 'none',
+          borderRadius: '6px 6px 0 0',
+          padding: '2px 6px',
+          cursor: 'pointer',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          minWidth: '24px',
+          height: '22px',
+          color: token.colorTextSecondary,
+          transition: 'all 0.2s',
+          zIndex: 1,
+        }}
+        onClick={props.onToggleCollapse}
+        onMouseEnter={(e) => {
+          e.currentTarget.style.color = token.colorText;
+          e.currentTarget.style.backgroundColor = token.colorBgTextHover;
+        }}
+        onMouseLeave={(e) => {
+          e.currentTarget.style.color = token.colorTextSecondary;
+          e.currentTarget.style.backgroundColor = token.colorBgContainer;
+        }}
+      >
+        <Antd.Tooltip title={props.isCollapsed ? t("EXPAND") : t("COLLAPSE")}>
+          {props.isCollapsed ? <ExpandIcon /> : <CollapseIcon />}
+        </Antd.Tooltip>
+      </div>
+    );
+  };
+
   return (
-    <Antd.Flex vertical gap="small" style={{ height: '100%' }}>
-      {renderHeader()}
-      {renderCodeBlock()}
-    </Antd.Flex>
+    <div style={{ height: '100%', position: 'relative' }}>
+      <Antd.Flex vertical gap="small" style={{ height: '100%' }}>
+        {renderHeader()}
+        {renderCodeBlock()}
+      </Antd.Flex>
+      {renderCollapseTrigger()}
+    </div>
   );
 }

--- a/src/reactComponents/CodeDisplay.tsx
+++ b/src/reactComponents/CodeDisplay.tsx
@@ -121,6 +121,7 @@ export default function CodeDisplay(props: CodeDisplayProps): React.JSX.Element 
       <SiderCollapseTrigger
         collapsed={props.isCollapsed || false}
         onToggle={props.onToggleCollapse}
+        isRightPanel={true}
       />
     );
   };

--- a/src/reactComponents/SiderCollapseTrigger.tsx
+++ b/src/reactComponents/SiderCollapseTrigger.tsx
@@ -1,0 +1,74 @@
+/**
+ * @license
+ * Copyright 2025 Porpoiseful LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @author alan@porpoiseful.com (Alan Smith)
+ */
+import * as React from 'react';
+import * as Antd from 'antd';
+import { LeftOutlined, RightOutlined } from '@ant-design/icons';
+import { useTranslation } from 'react-i18next';
+
+/** Props for the SiderCollapseTrigger component. */
+interface SiderCollapseTriggerProps {
+  collapsed: boolean;
+  onToggle: () => void;
+}
+
+/**
+ * Custom collapse trigger for Sider that matches the right panel's appearance.
+ */
+export default function SiderCollapseTrigger(props: SiderCollapseTriggerProps): React.JSX.Element {
+  const { token } = Antd.theme.useToken();
+  const { t } = useTranslation();
+  const [isHovered, setIsHovered] = React.useState(false);
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        bottom: 0,
+        left: '50%',
+        transform: 'translateX(-50%)',
+        backgroundColor: isHovered ? token.colorBgTextHover : token.colorBgContainer,
+        border: `1px solid ${token.colorBorder}`,
+        borderBottom: 'none',
+        borderRadius: '6px 6px 0 0',
+        padding: '2px 6px',
+        cursor: 'pointer',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        minWidth: '24px',
+        height: '22px',
+        color: isHovered ? token.colorText : token.colorTextSecondary,
+        transition: 'all 0.2s',
+        zIndex: 1,
+      }}
+      onClick={props.onToggle}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
+      <Antd.Tooltip title={props.collapsed ? t("EXPAND") : t("COLLAPSE")}>
+        {props.collapsed ? 
+          <RightOutlined style={{ fontSize: '12px', color: 'inherit' }} /> : 
+          <LeftOutlined style={{ fontSize: '12px', color: 'inherit' }} />
+        }
+      </Antd.Tooltip>
+    </div>
+  );
+}

--- a/src/reactComponents/SiderCollapseTrigger.tsx
+++ b/src/reactComponents/SiderCollapseTrigger.tsx
@@ -27,6 +27,7 @@ import { useTranslation } from 'react-i18next';
 interface SiderCollapseTriggerProps {
   collapsed: boolean;
   onToggle: () => void;
+  isRightPanel?: boolean;
 }
 
 /**
@@ -64,10 +65,17 @@ export default function SiderCollapseTrigger(props: SiderCollapseTriggerProps): 
       onMouseLeave={() => setIsHovered(false)}
     >
       <Antd.Tooltip title={props.collapsed ? t("EXPAND") : t("COLLAPSE")}>
-        {props.collapsed ? 
-          <RightOutlined style={{ fontSize: '12px', color: 'inherit' }} /> : 
-          <LeftOutlined style={{ fontSize: '12px', color: 'inherit' }} />
-        }
+        {props.isRightPanel ? (
+          // Right panel: reversed arrows
+          props.collapsed ? 
+            <LeftOutlined style={{ fontSize: '12px', color: 'inherit' }} /> : 
+            <RightOutlined style={{ fontSize: '12px', color: 'inherit' }} />
+        ) : (
+          // Left panel: normal arrows
+          props.collapsed ? 
+            <RightOutlined style={{ fontSize: '12px', color: 'inherit' }} /> : 
+            <LeftOutlined style={{ fontSize: '12px', color: 'inherit' }} />
+        )}
       </Antd.Tooltip>
     </div>
   );


### PR DESCRIPTION
This fixes #231.   

It also has some changes to the left menu so that the two would use the same component so they look and act the same.