### PR TITLE
Make the parameter name fields of an event block not editable

### DIFF
--- a/src/blocks/mrc_event.ts
+++ b/src/blocks/mrc_event.ts
@@ -22,6 +22,7 @@
 import * as Blockly from 'blockly';
 
 import { MRC_STYLE_EVENTS } from '../themes/styles'
+import { createFieldNonEditableText } from '../fields/FieldNonEditableText';
 import { Parameter } from './mrc_class_method_def';
 import { ExtendedPythonGenerator } from '../editor/extended_python_generator';
 import { MUTATOR_BLOCK_NAME, PARAM_CONTAINER_BLOCK_NAME, MethodMutatorArgBlock } from './mrc_param_container'
@@ -177,8 +178,7 @@ const EVENT = {
         this.removeParameterFields(input);
         this.mrcParameters.forEach((param) => {
           const paramName = FIELD_PARAM_PREFIX + param.name;
-          const field = new Blockly.FieldTextInput(param.name);
-          field.EDITABLE = false;
+          const field = createFieldNonEditableText(param.name);
           input.appendField(field, paramName);
         });
       }


### PR DESCRIPTION
Use createFieldNonEditableText for the parameters of a mrc_event block.

Fixes #275
