### PR TITLE
Fixed bug where creating a new module causes errors

### DIFF
--- a/src/reactComponents/AddTabDialog.tsx
+++ b/src/reactComponents/AddTabDialog.tsx
@@ -41,7 +41,7 @@ interface AddTabDialogProps {
   onOk: (newTab: TabItem) => void;
   onCancel: () => void;
   project: storageProject.Project | null;
-  setProject: (project: storageProject.Project | null) => void;
+  onProjectChanged: () => Promise<void>;
   currentTabs: TabItem[];
   storage: commonStorage.Storage | null;
 }
@@ -111,6 +111,7 @@ export default function AddTabDialog(props: AddTabDialogProps) {
 
     await storageProject.addModuleToProject(
         props.storage, props.project, moduleType, newClassName);
+    await props.onProjectChanged();
 
     const newModule = storageProject.findModuleByClassName(props.project, newClassName);
     if (newModule) {

--- a/src/reactComponents/FileManageModal.tsx
+++ b/src/reactComponents/FileManageModal.tsx
@@ -40,7 +40,7 @@ interface FileManageModalProps {
   isOpen: boolean;
   onClose: () => void;
   project: storageProject.Project | null;
-  setProject: (project: storageProject.Project | null) => void;
+  onProjectChanged: () => Promise<void>;
   gotoTab: (path: string) => void;
   setAlertErrorMessage: (message: string) => void;
   storage: commonStorage.Storage | null;
@@ -64,11 +64,6 @@ export default function FileManageModal(props: FileManageModalProps) {
   const [name, setName] = React.useState('');
   const [copyModalOpen, setCopyModalOpen] = React.useState(false);
 
-  const triggerProjectUpdate = (): void => {
-    if (props.project) {
-      props.setProject({...props.project});
-    }
-  }
   React.useEffect(() => {
     if (!props.project || props.tabType === null) {
       setModules([]);
@@ -109,6 +104,7 @@ export default function FileManageModal(props: FileManageModalProps) {
           newClassName,
           origModule.path
       );
+      await props.onProjectChanged();
 
       const newModules = modules.map((module) => {
         if (module.path === origModule.path) {
@@ -118,7 +114,6 @@ export default function FileManageModal(props: FileManageModalProps) {
       });
 
       setModules(newModules);
-      triggerProjectUpdate();
 
       // Close the rename modal first
       setRenameModalOpen(false);
@@ -147,6 +142,7 @@ export default function FileManageModal(props: FileManageModalProps) {
           newClassName,
           origModule.path
       );
+      await props.onProjectChanged();
 
       const originalModule = modules.find((module) => module.path === origModule.path);
       if (!originalModule) {
@@ -165,7 +161,6 @@ export default function FileManageModal(props: FileManageModalProps) {
       newModules.push(newModule);
 
       setModules(newModules);
-      triggerProjectUpdate();
       
       // Close the copy modal first
       setCopyModalOpen(false);
@@ -197,6 +192,7 @@ export default function FileManageModal(props: FileManageModalProps) {
         moduleType,
         newClassName
     );
+    await props.onProjectChanged();
 
     const newModule = storageProject.findModuleByClassName(props.project, newClassName);
     if (newModule) {
@@ -212,7 +208,7 @@ export default function FileManageModal(props: FileManageModalProps) {
     if(newModule){
       props.gotoTab(newModule.modulePath);
     }
-    triggerProjectUpdate();
+
     props.onClose();
   };
 
@@ -227,7 +223,7 @@ export default function FileManageModal(props: FileManageModalProps) {
           props.project,
           record.path
       );
-      triggerProjectUpdate();
+      await props.onProjectChanged();
     }
   };
 

--- a/src/reactComponents/Menu.tsx
+++ b/src/reactComponents/Menu.tsx
@@ -60,6 +60,7 @@ export interface MenuProps {
   gotoTab: (tabKey: string) => void;
   project: storageProject.Project | null;
   setProject: (project: storageProject.Project | null) => void;
+  onProjectChanged: () => Promise<void>;
   openWPIToolboxSettings: () => void;
   theme: string;
   setTheme: (theme: string) => void;
@@ -429,7 +430,7 @@ export function Component(props: MenuProps): React.JSX.Element {
         project={props.project}
         storage={props.storage}
         tabType={tabType}
-        setProject={props.setProject}
+        onProjectChanged={props.onProjectChanged}
         setAlertErrorMessage={props.setAlertErrorMessage}
         gotoTab={props.gotoTab}
       />


### PR DESCRIPTION
Fixed #279 

App.tsx:
Move fetchModules function from inside the useEffect callback for project to outside of it. Added onProjectChanged function that calls fetchModules and waits for it to complete. Pass onProjectChanged to Tabs and Menu components.

Tabs.tsx:
Added onProjectChanged to TabsProps. Removed setProject. Removed triggerProjectUpdate function.
Call await props.onProjectChange() when project is changed (after renameModuleInProject, copyModuleInProject, and removeModuleFromProject). Pass onProjectChange to AddTabDialog component.

AddTabDialog.tsx:
Added onProjectChanged to AddTabDialogProps. Removed setProject. Call await props.onProjectChange() when project is changed (after addModuleToProject).

Menu.tsx:
Added onProjectChanged to MenuProps.
Pass onProjectChange to FileManageModal component.

FileManageModal.tsx:
Added onProjectChanged to FileManageModalProps. Removed setProject. Removed triggerProjectUpdate function.
Call await props.onProjectChange() when project is changed (after renameModuleInProject, copyModuleInProject, addModuleToProject, and removeModuleFromProject).