### PR TITLE
Fix issue where call robot method block was missing the word robot

### DIFF
--- a/src/blocks/mrc_call_python_function.ts
+++ b/src/blocks/mrc_call_python_function.ts
@@ -211,7 +211,7 @@ const CALL_PYTHON_FUNCTION = {
         }
         case FunctionKind.EVENT: {
           const eventName = this.getFieldValue(FIELD_EVENT_NAME);
-          tooltip = Blockly.Msg.CALL_INSTANCE_METHOD_WITHIN_TOOLTIP;
+          tooltip = Blockly.Msg.FIRE_EVENT_TOOLTIP;
           tooltip = tooltip.replace('{{eventName}}', eventName);
           break;
         }
@@ -219,14 +219,14 @@ const CALL_PYTHON_FUNCTION = {
           const className = this.mrcComponentClassName;
           const functionName = this.getFieldValue(FIELD_FUNCTION_NAME);
           if (this.mrcMechanismId) {
-            tooltip = Blockly.Msg.CALL_MECHANISM_COMPONENT_INSTANCE_METHOD;
+            tooltip = Blockly.Msg.CALL_MECHANISM_COMPONENT_INSTANCE_METHOD_TOOLTIP;
             tooltip = tooltip
                 .replace('{{className}}', className)
                 .replace('{{functionName}}', functionName)
                 .replace('{{componentName}}', this.getFieldValue(FIELD_COMPONENT_NAME))
                 .replace('{{mechanismName}}', this.getFieldValue(FIELD_MECHANISM_NAME));
           } else {
-            tooltip = Blockly.Msg.CALL_COMPONENT_INSTANCE_METHOD;
+            tooltip = Blockly.Msg.CALL_COMPONENT_INSTANCE_METHOD_TOOLTIP;
             tooltip = tooltip
                 .replace('{{className}}', className)
                 .replace('{{functionName}}', functionName)
@@ -236,18 +236,18 @@ const CALL_PYTHON_FUNCTION = {
         }
         case FunctionKind.INSTANCE_ROBOT: {
           const functionName = this.getFieldValue(FIELD_FUNCTION_NAME);
-          tooltip = Blockly.Msg.CALL_INSTANCE_METHOD_WITHIN_TOOLTIP;
+          tooltip = Blockly.Msg.CALL_ROBOT_INSTANCE_METHOD_TOOLTIP;
           tooltip = tooltip.replace('{{functionName}}', functionName);
           break;
         }
         case FunctionKind.INSTANCE_MECHANISM: {
           const className = this.mrcMechanismClassName;
           const functionName = this.getFieldValue(FIELD_FUNCTION_NAME);
-            tooltip = Blockly.Msg.CALL_MECHANISM_INSTANCE_METHOD;
-            tooltip = tooltip
-                .replace('{{className}}', className)
-                .replace('{{functionName}}', functionName)
-                .replace('{{mechanismName}}', this.getFieldValue(FIELD_MECHANISM_NAME));
+          tooltip = Blockly.Msg.CALL_MECHANISM_INSTANCE_METHOD_TOOLTIP;
+          tooltip = tooltip
+              .replace('{{className}}', className)
+              .replace('{{functionName}}', functionName)
+              .replace('{{mechanismName}}', this.getFieldValue(FIELD_MECHANISM_NAME));
           break;
         }
         default:
@@ -436,7 +436,7 @@ const CALL_PYTHON_FUNCTION = {
         case FunctionKind.INSTANCE_ROBOT: {
           this.appendDummyInput(INPUT_TITLE)
               .appendField(Blockly.Msg.CALL)
-              .appendField(createFieldNonEditableText(Blockly.Msg.ROBOT))
+              .appendField(createFieldNonEditableText(Blockly.Msg.ROBOT_LOWER_CASE))
               .appendField('.')
               .appendField(createFieldNonEditableText(''), FIELD_FUNCTION_NAME);
           break;

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -140,7 +140,7 @@
         "PRINT": "print",
         "NO_MECHANISM_CONTENTS": "No Mechanism Contents",
         "CALL": "call",
-        "ROBOT": "robot",
+        "ROBOT_LOWER_CASE": "robot",
         "CREATE": "create",
         "FIRE": "fire",
         "GET": "get",

--- a/src/i18n/locales/es/translation.json
+++ b/src/i18n/locales/es/translation.json
@@ -141,7 +141,7 @@
         "PRINT": "imprimir",
         "NO_MECHANISM_CONTENTS": "Sin Contenido de Mecanismo",
         "CALL": "llamar",
-        "ROBOT": "robot",
+        "ROBOT_LOWER_CASE": "robot",
         "CREATE": "crear",
         "FIRE": "disparar",
         "GET": "obtener",

--- a/src/i18n/locales/he/translation.json
+++ b/src/i18n/locales/he/translation.json
@@ -140,7 +140,7 @@
     "PRINT": "הדפס",
     "NO_MECHANISM_CONTENTS": "אין תוכן במנגנון",
     "CALL": "קרא",
-    "ROBOT": "רובוט",
+    "ROBOT_LOWER_CASE": "רובוט",
     "CREATE": "צור",
     "FIRE": "הפעל",
     "GET": "קבל",


### PR DESCRIPTION
Fixed issue where block to call a robot method was missing the word "robot".

Also fixed several tooltips which were incorrect.

Fixes #288 