### PR TITLE
Fixed problem where toolbox doesn't show mechanism that was just added to the robot

### DIFF
--- a/src/reactComponents/TabContent.tsx
+++ b/src/reactComponents/TabContent.tsx
@@ -86,7 +86,11 @@ export const TabContent = React.forwardRef<TabContentRef, TabContentProps>(({
   React.useImperativeHandle(ref, () => ({
     saveModule: async () => {
       if (editorInstance) {
-        await editorInstance.saveModule();
+        const moduleContentText = await editorInstance.saveModule();
+        // Update modulePathToContentText.
+        // modulePathToContentText is passed to Editor.makeCurrent so the active editor will know
+        // about changes to other modules.
+        modulePathToContentText[modulePath] = moduleContentText;
       }
     },
   }), [editorInstance]);

--- a/src/reactComponents/Tabs.tsx
+++ b/src/reactComponents/Tabs.tsx
@@ -84,15 +84,17 @@ export function Component(props: TabsProps): React.JSX.Element {
   const tabContentRefs = React.useRef<Map<string, TabContentRef>>(new Map());
 
   /** Handles tab change and updates current module. */
-  const handleTabChange = (key: string): void => {
+  const handleTabChange = async (key: string): Promise<void> => {
     if (key !== activeKey) {
-      // Save the tab we are changing away from (async, but don't wait)
+      // Save the tab we are changing away from. Wait for the save to complete before changing tabs.
       const currentTabRef = tabContentRefs.current.get(activeKey);
       if (currentTabRef) {
-        currentTabRef.saveModule().catch((error) => {
+        try {
+          await currentTabRef.saveModule();
+        } catch(error) {
           console.error('Error saving module on tab switch:', error);
           props.setAlertErrorMessage(t('FAILED_TO_SAVE_MODULE'));
-        });
+        }
       }
     }
     setActiveKey(key);


### PR DESCRIPTION
Fixed problem where toolbox doesn't show mechanism that was just added to the robot.

Steps to reproduce the problem:
1. Make a new project
2. Add a mechanism "Arm" from the + next to Tabs
3. Click on the Robot tab.
4. Add the mechanism (my_arm) to the Robot.
5. Click on the Teleop tab.
6. The mechanism should be in the toolbox (Robot -> Mechanisms -> my_arm)

Details:
Modified Tabs so it waits for the saveModule to finish before switching tabs.
Modified TabContent so when a module is saved, it updates modulePathToContentText.