### PR TITLE
Store component information for each parameter in mrc_mechanism blocks

### DIFF
--- a/src/blocks/mrc_mechanism.ts
+++ b/src/blocks/mrc_mechanism.ts
@@ -57,7 +57,6 @@ type MechanismExtraState = {
   mechanismId?: string,
   importModule?: string,
   parameters?: Parameter[],
-  parametersHaveComponentInformation?: boolean,
 }
 
 const WARNING_ID_NOT_IN_HOLDER = 'not in holder';
@@ -69,7 +68,6 @@ interface MechanismMixin extends MechanismMixinType {
   mrcMechanismId: string,
   mrcImportModule: string,
   mrcParameters: Parameter[],
-  mrcParametersHaveComponentInformation: boolean,
 
   /**
    * mrcHasNotInHolderWarning is set to true if we set the NOT_IN_HOLDER warning text on the block.
@@ -87,7 +85,6 @@ const MECHANISM = {
     * Block initialization.
     */
   init: function (this: MechanismBlock): void {
-    this.mrcParametersHaveComponentInformation = false;
     this.mrcHasNotInHolderWarning = false;
     this.setStyle(MRC_STYLE_MECHANISMS);
     const nameField = new Blockly.FieldTextInput('')
@@ -107,7 +104,6 @@ const MECHANISM = {
     const extraState: MechanismExtraState = {
       mechanismModuleId: this.mrcMechanismModuleId,
       mechanismId: this.mrcMechanismId,
-      parametersHaveComponentInformation: this.mrcParametersHaveComponentInformation,
     };
     extraState.parameters = [];
     this.mrcParameters.forEach((arg) => {
@@ -131,8 +127,6 @@ const MECHANISM = {
         this.mrcParameters.push({...arg});
       });
     }
-    this.mrcParametersHaveComponentInformation = (extraState.parametersHaveComponentInformation == undefined)
-        ? false : extraState.parametersHaveComponentInformation;
     this.updateBlock_();
   },
   /**
@@ -302,7 +296,6 @@ const MECHANISM = {
           componentPortsIndex++;
         }
       });
-      this.mrcParametersHaveComponentInformation = true;
       this.updateBlock_();
     } else {
       // Did not find the mechanism.
@@ -330,12 +323,6 @@ const MECHANISM = {
     if (this.mrcMechanismId in oldIdToNewId) {
       this.mrcMechanismId = oldIdToNewId[this.mrcMechanismId];
     }
-  },
-  upgrade_005_to_006: function(this: MechanismBlock) {
-    // At the time when this upgrade method is called, we can't look up the component information
-    // for each parameter. Instead, we just mark this block as not having the information. Later,
-    // in the checkMechanism method, we will retrieve the component information for each parameter.
-    this.mrcParametersHaveComponentInformation = false;
   },
 };
 
@@ -372,7 +359,6 @@ export function createMechanismBlock(
     mechanismModuleId: mechanism.moduleId,
     importModule: snakeCaseName,
     parameters: [],
-    parametersHaveComponentInformation: true,
   };
   const inputs: {[key: string]: any} = {};
   let i = 0;
@@ -395,14 +381,4 @@ export function createMechanismBlock(
   fields[FIELD_NAME] = mechanismName;
   fields[FIELD_TYPE] = mechanism.className;
   return new toolboxItems.Block(BLOCK_NAME, extraState, fields, inputs);
-}
-
-/**
- * Upgrades the MechanismBlocks in the given workspace from version 005 to 006.
- * This function should only be called when upgrading old projects.
- */
-export function upgrade_005_to_006(workspace: Blockly.Workspace): void {
-  workspace.getBlocksByType(BLOCK_NAME).forEach(block => {
-    (block as MechanismBlock).upgrade_005_to_006();
-  });
 }

--- a/src/storage/upgrade_project.ts
+++ b/src/storage/upgrade_project.ts
@@ -29,11 +29,10 @@ import * as storageNames from './names';
 import * as storageProject from './project';
 import { upgrade_001_to_002 } from '../blocks/mrc_mechanism_component_holder';
 import { upgrade_002_to_003, upgrade_004_to_005 } from '../blocks/mrc_class_method_def';
-import { upgrade_005_to_006 } from '../blocks/mrc_mechanism';
 import * as workspaces from '../blocks/utils/workspaces';
 
 export const NO_VERSION = '0.0.0';
-export const CURRENT_VERSION = '0.0.6';
+export const CURRENT_VERSION = '0.0.5';
 
 export async function upgradeProjectIfNecessary(
     storage: commonStorage.Storage, projectName: string): Promise<void> {
@@ -67,11 +66,6 @@ export async function upgradeProjectIfNecessary(
       // @ts-ignore
       case '0.0.4':
         upgradeFrom_004_to_005(storage, projectName, projectInfo);
-
-      // Intentional fallthrough after case '0.0.5'
-      // @ts-ignore
-      case '0.0.5':
-        upgradeFrom_005_to_006(storage, projectName, projectInfo);
     }
     await storageProject.saveProjectInfo(storage, projectName);
   }
@@ -217,16 +211,4 @@ async function upgradeFrom_004_to_005(
       noModuleTypes, noPreupgrade,
       anyModuleType, upgrade_004_to_005);
   projectInfo.version = '0.0.5';
-}
-
-async function upgradeFrom_005_to_006(
-    storage: commonStorage.Storage,
-    projectName: string,
-    projectInfo: storageProject.ProjectInfo): Promise<void> {
-  // mrc_mechanism blocks may have component information for each parameter.
-  await upgradeBlocksFiles(
-      storage, projectName,
-      noModuleTypes, noPreupgrade,
-      anyModuleType, upgrade_005_to_006);
-  projectInfo.version = '0.0.6';
 }


### PR DESCRIPTION
Store component information for each parameter in mrc_mechanism blocks.

Incremented version to 0.0.6. Added upgradeFrom_005_to_006.

This PR is in preparation for tackling issue #286, which I will do in a separate PR.
