### PR TITLE
Fix type for component blocks params

### DIFF
--- a/src/blocks/mrc_component.ts
+++ b/src/blocks/mrc_component.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  * Copyright 2025 Porpoiseful LLC
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -192,7 +192,7 @@ const COMPONENT = {
     // Collect the ports for this component block.
     for (let i = 0; i < this.mrcArgs.length; i++) {
       const argName = this.getArgName(i);
-      ports[argName] = this.mrcArgs[i].name;  
+      ports[argName] = this.mrcArgs[i].name;
     }
   },
   /**
@@ -245,6 +245,13 @@ const COMPONENT = {
   mrcChangeIds: function (this: ComponentBlock, oldIdToNewId: { [oldId: string]: string }): void {
     if (this.mrcComponentId in oldIdToNewId) {
       this.mrcComponentId = oldIdToNewId[this.mrcComponentId];
+    }
+  },
+  upgrade_005_to_006: function(this: ComponentBlock) {
+    for (let i = 0; i < this.mrcArgs.length; i++) {
+      if (this.mrcArgs[i].type === 'Port') {
+        this.mrcArgs[i].type = this.mrcArgs[i].name;
+      }
     }
   },
 };
@@ -318,11 +325,21 @@ function createComponentBlock(
   if (constructorData.expectedPortType) {
     extraState.params!.push({
       name: constructorData.expectedPortType,
-      type: 'Port',
+      type: constructorData.expectedPortType,
     });
-    if ( moduleType == storageModule.ModuleType.ROBOT ) {
+    if (moduleType == storageModule.ModuleType.ROBOT ) {
       inputs['ARG0'] = createPort(constructorData.expectedPortType);
     }
   }
   return new toolboxItems.Block(BLOCK_NAME, extraState, fields, Object.keys(inputs).length ? inputs : null);
+}
+
+/**
+ * Upgrades the ComponentBlocks in the given workspace from version 005 to 006.
+ * This function should only be called when upgrading old projects.
+ */
+export function upgrade_005_to_006(workspace: Blockly.Workspace): void {
+  workspace.getBlocksByType(BLOCK_NAME).forEach(block => {
+    (block as ComponentBlock).upgrade_005_to_006();
+  });
 }

--- a/src/blocks/mrc_port.ts
+++ b/src/blocks/mrc_port.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  * Copyright 2025 Porpoiseful LLC
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -26,6 +26,7 @@ import { MRC_STYLE_PORTS } from '../themes/styles'
 import { createFieldNonEditableText } from '../fields/FieldNonEditableText';
 import { ExtendedPythonGenerator } from '../editor/extended_python_generator';
 import { createFieldNumberDropdown } from '../fields/field_number_dropdown';
+import { getOutputCheck } from './utils/python';
 
 export const BLOCK_NAME = 'mrc_port';
 export const OUTPUT_NAME = 'mrc_port';
@@ -119,6 +120,7 @@ const PORT = {
     }
     this.mrcPortType = state.portType;
     this.mrcPortCount = iField;
+    this.setOutput(true, getOutputCheck(this.mrcPortType));
   },
 }
 

--- a/src/storage/upgrade_project.ts
+++ b/src/storage/upgrade_project.ts
@@ -29,10 +29,11 @@ import * as storageNames from './names';
 import * as storageProject from './project';
 import { upgrade_001_to_002 } from '../blocks/mrc_mechanism_component_holder';
 import { upgrade_002_to_003, upgrade_004_to_005 } from '../blocks/mrc_class_method_def';
+import { upgrade_005_to_006 } from '../blocks/mrc_component';
 import * as workspaces from '../blocks/utils/workspaces';
 
 export const NO_VERSION = '0.0.0';
-export const CURRENT_VERSION = '0.0.5';
+export const CURRENT_VERSION = '0.0.6';
 
 export async function upgradeProjectIfNecessary(
     storage: commonStorage.Storage, projectName: string): Promise<void> {
@@ -66,6 +67,11 @@ export async function upgradeProjectIfNecessary(
       // @ts-ignore
       case '0.0.4':
         upgradeFrom_004_to_005(storage, projectName, projectInfo);
+
+      // Intentional fallthrough after case '0.0.5'
+      // @ts-ignore
+      case '0.0.5':
+        upgradeFrom_005_to_006(storage, projectName, projectInfo);
     }
     await storageProject.saveProjectInfo(storage, projectName);
   }
@@ -211,4 +217,16 @@ async function upgradeFrom_004_to_005(
       noModuleTypes, noPreupgrade,
       anyModuleType, upgrade_004_to_005);
   projectInfo.version = '0.0.5';
+}
+
+async function upgradeFrom_005_to_006(
+    storage: commonStorage.Storage,
+    projectName: string,
+    projectInfo: storageProject.ProjectInfo): Promise<void> {
+  // mrc_component blocks parameter types need to be fixed.
+  await upgradeBlocksFiles(
+      storage, projectName,
+      noModuleTypes, noPreupgrade,
+      anyModuleType, upgrade_005_to_006);
+  projectInfo.version = '0.0.6';
 }


### PR DESCRIPTION
Fix type for component blocks params.

Incremented version to 0.0.6. Added upgradeFrom_005_to_006.

In mrc_component.ts:
Change the arg type from 'Port' to the real port type.

In mrc_port.ts:
In loadExtraState, call setOutput with the appropriate output check for the port type.

Fixes #322 