### PR TITLE
Don't allow certain blocks to be copied

### DIFF
--- a/src/blocks/mrc_class_method_def.ts
+++ b/src/blocks/mrc_class_method_def.ts
@@ -35,6 +35,7 @@ import * as toolboxItems from '../toolbox/items';
 import { getClassData } from './utils/python';
 import { FunctionData } from './utils/python_json_types';
 import { findConnectedBlocksOfType } from './utils/find_connected_blocks';
+import { NONCOPYABLE_BLOCK } from './noncopyable_block';
 import { BLOCK_NAME as MRC_GET_PARAMETER_BLOCK_NAME } from './mrc_get_parameter';
 import * as paramContainer from './mrc_param_container'
 
@@ -122,6 +123,7 @@ const CLASS_METHOD_DEF = {
     this.setNextStatement(false);
     this.updateBlock_();
   },
+  ...NONCOPYABLE_BLOCK,
   /**
    * Returns the state of this block as a JSON serializable object.
    */

--- a/src/blocks/mrc_component.ts
+++ b/src/blocks/mrc_component.ts
@@ -31,6 +31,7 @@ import { getAllowedTypesForSetCheck, getClassData, getSubclassNames } from './ut
 import * as toolboxItems from '../toolbox/items';
 import * as storageModule from '../storage/module';
 import * as storageModuleContent from '../storage/module_content';
+import { NONCOPYABLE_BLOCK } from './noncopyable_block';
 import {
     BLOCK_NAME as MRC_MECHANISM_COMPONENT_HOLDER,
     MechanismComponentHolderBlock,
@@ -100,6 +101,7 @@ const COMPONENT = {
     this.setPreviousStatement(true, OUTPUT_NAME);
     this.setNextStatement(true, OUTPUT_NAME);
   },
+  ...NONCOPYABLE_BLOCK,
 
   /**
     * Returns the state of this block as a JSON serializable object.

--- a/src/blocks/mrc_event.ts
+++ b/src/blocks/mrc_event.ts
@@ -26,6 +26,7 @@ import { createFieldNonEditableText } from '../fields/FieldNonEditableText';
 import { Parameter } from './mrc_class_method_def';
 import { Editor } from '../editor/editor';
 import { ExtendedPythonGenerator } from '../editor/extended_python_generator';
+import { NONCOPYABLE_BLOCK } from './noncopyable_block';
 import * as paramContainer from './mrc_param_container'
 import {
     BLOCK_NAME as MRC_MECHANISM_COMPONENT_HOLDER,
@@ -80,6 +81,7 @@ const EVENT = {
     this.setNextStatement(true, OUTPUT_NAME);
     this.updateBlock_();
   },
+  ...NONCOPYABLE_BLOCK,
 
   /**
    * Returns the state of this block as a JSON serializable object.

--- a/src/blocks/mrc_mechanism.ts
+++ b/src/blocks/mrc_mechanism.ts
@@ -31,6 +31,7 @@ import * as toolboxItems from '../toolbox/items';
 import * as storageModule from '../storage/module';
 import * as storageModuleContent from '../storage/module_content';
 import * as storageNames from '../storage/names';
+import { NONCOPYABLE_BLOCK } from './noncopyable_block';
 import {
     BLOCK_NAME as MRC_MECHANISM_COMPONENT_HOLDER,
     MechanismComponentHolderBlock,
@@ -94,6 +95,7 @@ const MECHANISM = {
     this.setPreviousStatement(true, OUTPUT_NAME);
     this.setNextStatement(true, OUTPUT_NAME);
   },
+  ...NONCOPYABLE_BLOCK,
 
   /**
     * Returns the state of this block as a JSON serializable object.

--- a/src/blocks/mrc_mechanism_component_holder.ts
+++ b/src/blocks/mrc_mechanism_component_holder.ts
@@ -27,6 +27,7 @@ import { Editor } from '../editor/editor';
 import { ExtendedPythonGenerator } from '../editor/extended_python_generator';
 import * as storageModule from '../storage/module';
 import * as storageModuleContent from '../storage/module_content';
+import { NONCOPYABLE_BLOCK } from './noncopyable_block';
 import { BLOCK_NAME as  MRC_MECHANISM_NAME } from './mrc_mechanism';
 import { OUTPUT_NAME as MECHANISM_OUTPUT } from './mrc_mechanism';
 import { MechanismBlock } from './mrc_mechanism';
@@ -79,6 +80,7 @@ const MECHANISM_COMPONENT_HOLDER = {
     this.mrcEventBlockIds = '';
     this.mrcToolboxUpdateTimeout = null;
   },
+  ...NONCOPYABLE_BLOCK,
   saveExtraState: function (this: MechanismComponentHolderBlock): MechanismComponentHolderExtraState {
     const extraState: MechanismComponentHolderExtraState = {
     };

--- a/src/blocks/mrc_opmode_details.ts
+++ b/src/blocks/mrc_opmode_details.ts
@@ -27,6 +27,7 @@ import { Editor } from '../editor/editor';
 import { ExtendedPythonGenerator, OpModeDetails } from '../editor/extended_python_generator';
 import { createFieldDropdown } from '../fields/FieldDropdown';
 import { MRC_STYLE_CLASS_BLOCKS } from '../themes/styles';
+import { NONCOPYABLE_BLOCK } from './noncopyable_block';
 
 export const BLOCK_NAME = 'mrc_opmode_details';
 
@@ -65,6 +66,7 @@ const OPMODE_DETAILS = {
     this.getField('NAME')?.setTooltip(Blockly.Msg.OPMODE_NAME_TOOLTIP);
     this.getField('GROUP')?.setTooltip(Blockly.Msg.OPMODE_GROUP_TOOLTIP);
   },
+  ...NONCOPYABLE_BLOCK,
   checkOpMode(this: OpmodeDetailsBlock, editor: Editor): void {
     if (editor.isStepsInWorkspace() ||
         editor.getMethodNamesAlreadyOverriddenInWorkspace().includes(PERIODIC_METHOD_NAME)) {

--- a/src/blocks/mrc_steps.ts
+++ b/src/blocks/mrc_steps.ts
@@ -16,7 +16,7 @@
  */
 
 /**
- * @fileoverview Blocks for class method definition
+ * @fileoverview Block for defining steps.
  * @author alan@porpoiseful.com (Alan Smith)
  */
 import * as Blockly from 'blockly';
@@ -25,6 +25,7 @@ import { Order } from 'blockly/python';
 import { MRC_STYLE_STEPS } from '../themes/styles';
 import { ExtendedPythonGenerator } from '../editor/extended_python_generator';
 import { createStepFieldFlydown } from '../fields/field_flydown';
+import { NONCOPYABLE_BLOCK } from './noncopyable_block';
 import { renameSteps as updateJumpToStepBlocks } from './mrc_jump_to_step';
 import * as stepContainer from './mrc_step_container'
 import { createBooleanShadowValue } from './utils/value';
@@ -63,6 +64,7 @@ const STEPS = {
     this.setStyle(MRC_STYLE_STEPS);
     this.setMutator(stepContainer.getMutatorIcon(this));
   },
+  ...NONCOPYABLE_BLOCK,
   saveExtraState: function (this: StepsBlock): StepsExtraState {
     return {
       stepNames: this.mrcStepNames,

--- a/src/blocks/noncopyable_block.ts
+++ b/src/blocks/noncopyable_block.ts
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @author lizlooney@google.com (Liz Looney)
+ */
+
+import * as Blockly from 'blockly';
+
+export const NONCOPYABLE_BLOCK = {
+  isCopyable: function(this: Blockly.BlockSvg): boolean {
+    // We don't allow copying, but we return true here so that toCopyData will
+    // be called. The default in blockly is that a block is only copyable if it
+    // is both deletable and movable.
+    return true;
+  },
+  toCopyData: function(this: Blockly.BlockSvg, _addNextBlocks = false): Blockly.clipboard.BlockCopyData | null {
+    // We don't allow copying, but we return null here so the previous contents
+    // of the clipboard is cleared.
+    return null;
+  },
+}


### PR DESCRIPTION
Don't allow certain blocks to be copied. Clear previous clipboard data.

Fixes #320 
Fixes #325 