### PR TITLE
change so deployed pages will have the correct base address

### DIFF
--- a/.github/workflows/deploy_gh_pages.yml
+++ b/.github/workflows/deploy_gh_pages.yml
@@ -20,6 +20,10 @@
           - name: Install dependencies
             run: npm install
 
+          - name: Update base URL for GitHub Pages
+            run: |
+              sed -i "s|base: '/blocks/',|base: '/systemcore-blocks-interface/',|" vite.config.mts
+
           - name: Build package
             run: npm run build # Replace with your build command, outputting to e.g., 'dist'
 


### PR DESCRIPTION
This makes Deployed pages use the base address that has to be used to be part of the github pages.

Fixes Issue #342 