### PR TITLE
When validating names, only look at mechanism and component blocks

### DIFF
--- a/src/blocks/mrc_mechanism_component_holder.ts
+++ b/src/blocks/mrc_mechanism_component_holder.ts
@@ -221,7 +221,10 @@ const MECHANISM_COMPONENT_HOLDER = {
   setNameOfChildBlock(this: MechanismComponentHolderBlock, child: Blockly.Block): void {
     const otherNames: string[] = []
     this.getDescendants(true)
-        .filter(descendant => descendant.type === MRC_MECHANISM_NAME || descendant.type === MRC_COMPONENT_NAME)
+        .filter(descendant =>
+            descendant.type === MRC_MECHANISM_NAME ||
+            descendant.type === MRC_COMPONENT_NAME ||
+            descendant.type === MRC_EVENT_NAME)
         .filter(descendant => descendant.id !== child.id)
         .forEach(descendant => {
           otherNames.push(descendant.getFieldValue('NAME'));


### PR DESCRIPTION
When validating names, only look at mechanism and component blocks.

Fixes #351 