### PR TITLE
Fixed bug in MechanismBlock.checkMechanism when it adds port blocks to empty input sockets

### DIFF
--- a/src/blocks/mrc_mechanism.ts
+++ b/src/blocks/mrc_mechanism.ts
@@ -383,7 +383,7 @@ const MECHANISM = {
         let argInput = this.getInput('ARG' + i);
         if (argInput && argInput.connection && !argInput.connection.targetBlock()) {
           // The input is empty. Create a port block and connect it to the input.
-          const portBlockState = createPort(this.mrcParameters[i].type);
+          const portBlockState = createPort(this.mrcParameters[i].type).block;
           const portBlock = this.workspace.newBlock(portBlockState.type) as Blockly.BlockSvg;
           if (portBlockState.extraState && portBlock.loadExtraState) {
             portBlock.loadExtraState(portBlockState.extraState);


### PR DESCRIPTION
Fixed bug in MechanismBlock.checkMechanism when it adds port blocks to empty input sockets.

Fixes #354 