### PR TITLE
Pr simplify

### DIFF
--- a/src/reactComponents/Tabs.tsx
+++ b/src/reactComponents/Tabs.tsx
@@ -62,7 +62,6 @@ export interface TabsProps {
   storage: commonStorage.Storage | null;
   theme: string;
   shownPythonToolboxCategories: Set<string>;
-  modulePathToContentText: {[modulePath: string]: string};
   messageApi: MessageInstance;
 }
 
@@ -429,7 +428,6 @@ export const Component = React.forwardRef<TabsRef, TabsProps>((props, ref): Reac
             storage={props.storage}
             theme={props.theme}
             shownPythonToolboxCategories={props.shownPythonToolboxCategories}
-            modulePathToContentText={props.modulePathToContentText}
             messageApi={props.messageApi}
             setAlertErrorMessage={props.setAlertErrorMessage}
             isActive={activeKey === tab.key}


### PR DESCRIPTION
The purpose of this PR is to get rid of the unneeded vestiges from singular workspace to simplify and to make less occurrences for race condiditons.

This has two changes.  First is removing the idea of a currentEditor (because the tabs does that for us)
Second is to get rid of the modulePathToContentText cache. 

I did run through the testing_before_pr_checklist for this and everything passed on my computer.

Fixes #307 
