### PR TITLE
Fixes changing projects not selecting a tab

### DIFF
--- a/src/reactComponents/Tabs.tsx
+++ b/src/reactComponents/Tabs.tsx
@@ -448,8 +448,11 @@ export const Component = React.forwardRef<TabsRef, TabsProps>((props, ref): Reac
       setActiveKey(newActiveKey);
     } else if (props.tabList.length === 0) {
       setActiveKey('');
+    } else if (activeKey === '' && props.tabList.length > 0) {
+      // No active tab but tabs exist, activate the first tab
+      setActiveKey(props.tabList[0].key);
     }
-  }, [props.tabList.length]);
+  }, [props.tabList, activeKey]);
 
   return (
     <>


### PR DESCRIPTION
Fixes #371 

There was a problem when you changed projects where there would be no active tab.   