### PR TITLE
Make DutyCycleEncoder a component

### DIFF
--- a/python_tools/json_util.py
+++ b/python_tools/json_util.py
@@ -520,6 +520,21 @@ class JsonGenerator:
       class_data[_KEY_IS_COMPONENT] = True
       return
 
+    if declaring_class_name == 'wpilib.DutyCycleEncoder':
+      if (len(arg_names) == 4 and
+          arg_names[0] == 'self' and
+          arg_names[1] == 'channel' and
+          arg_names[2] == 'fullRange' and
+          arg_names[3] == 'expectedZero'):
+        args = []
+        args.append(self._createArgData('smart_io_port', 'SYSTEMCORE_SMART_IO_PORT'))
+        args.append(self._createArgData('full_range', self._getClassName(arg_types[2]), '1'))
+        args.append(self._createArgData('expected_zero', self._getClassName(arg_types[3]), '0'))
+        constructor_data[_KEY_COMPONENT_ARGS] = args
+        constructor_data[_KEY_IS_COMPONENT] = True
+        class_data[_KEY_IS_COMPONENT] = True
+      return
+
     if declaring_class_name == 'wpilib.OnboardIMU':
       if (len(arg_names) == 2 and
           arg_names[0] == 'self' and

--- a/src/blocks/utils/generated/robotpy_data.json
+++ b/src/blocks/utils/generated/robotpy_data.json
@@ -5463,8 +5463,26 @@
                             "type": "float"
                         }
                     ],
+                    "componentArgs": [
+                        {
+                            "defaultValue": "",
+                            "name": "smart_io_port",
+                            "type": "SYSTEMCORE_SMART_IO_PORT"
+                        },
+                        {
+                            "defaultValue": "1",
+                            "name": "full_range",
+                            "type": "float"
+                        },
+                        {
+                            "defaultValue": "0",
+                            "name": "expected_zero",
+                            "type": "float"
+                        }
+                    ],
                     "declaringClassName": "wpilib.DutyCycleEncoder",
                     "functionName": "__init__",
+                    "isComponent": true,
                     "returnType": "wpilib.DutyCycleEncoder",
                     "tooltip": "Construct a new DutyCycleEncoder on a specific channel.\n\n:param channel:      the channel to attach to\n:param fullRange:    the value to report at maximum travel\n:param expectedZero: the reading where you would expect a 0 from get()"
                 },
@@ -5643,7 +5661,7 @@
                 }
             ],
             "instanceVariables": [],
-            "isComponent": false,
+            "isComponent": true,
             "moduleName": "wpilib",
             "staticMethods": []
         },


### PR DESCRIPTION
Make DutyCycleEncoder a component.

As discussed in the system core meeting on 1/7/2026, the REV through bore encoder can be used as a DutyCycleEncoder.