### PR TITLE
Use camelCase instead of snake_case

### DIFF
--- a/frontend/blocks/mrc_call_python_function.ts
+++ b/frontend/blocks/mrc_call_python_function.ts
@@ -1210,7 +1210,7 @@ export function pythonFromBlock(
     }
     case FunctionKind.EVENT: {
       const eventName = block.getFieldValue(FIELD_EVENT_NAME);
-      code = 'self.fire_event(\'' + eventName + '\'';
+      code = 'self.fireEvent(\'' + eventName + '\'';
       needOpenParen = false;
       delimiterBeforeArgs = ', ';
       break;

--- a/frontend/blocks/mrc_class_method_def.ts
+++ b/frontend/blocks/mrc_class_method_def.ts
@@ -425,6 +425,24 @@ const CLASS_METHOD_DEF = {
       this.setFieldValue('periodic', FIELD_METHOD_NAME);
     }
   },
+  upgrade_0013_to_0014: function(this: ClassMethodDefBlock) {
+    // opmode_start is now opmodeStart
+    // opmode_periodic is now opmodePeriodic
+    // opmode_end is now opmodeEnd
+    if (!this.mrcCanChangeSignature &&
+        !this.mrcCanBeCalledWithinClass &&
+        !this.mrcCanBeCalledOutsideClass &&
+        this.mrcReturnType === 'None' &&
+        this.mrcParameters.length === 0) {
+      if (this.getFieldValue('NAME') === 'opmode_start') {
+        this.setFieldValue('opmodeStart', FIELD_METHOD_NAME);
+      } else if (this.getFieldValue('NAME') === 'opmode_periodic') {
+        this.setFieldValue('opmodePeriodic', FIELD_METHOD_NAME);
+      } else if (this.getFieldValue('NAME') === 'opmode_end') {
+        this.setFieldValue('opmodeEnd', FIELD_METHOD_NAME);
+      }
+    }
+  },
 };
 
 export const setup = function () {
@@ -534,7 +552,7 @@ export function createCustomMethodBlock(): toolboxItems.Block {
     params: [],
   };
   const fields: {[key: string]: any} = {};
-  fields[FIELD_METHOD_NAME] = 'my_method';
+  fields[FIELD_METHOD_NAME] = 'myMethod';
   return new toolboxItems.Block(BLOCK_NAME, extraState, fields, null);
 }
 
@@ -547,7 +565,7 @@ export function createCustomMethodBlockWithReturn(): toolboxItems.Block {
       params: [],
   };
   const fields: {[key: string]: any} = {};
-  fields[FIELD_METHOD_NAME] = 'my_method_with_return';
+  fields[FIELD_METHOD_NAME] = 'myMethodWithReturn';
   const inputs: {[key: string]: any} = {};
   inputs[INPUT_RETURN] = {
     type: 'input_value',
@@ -692,5 +710,15 @@ export function upgrade_007_to_008(workspace: Blockly.Workspace): void {
 export function upgrade_0011_to_0012(workspace: Blockly.Workspace): void {
   workspace.getBlocksByType(BLOCK_NAME).forEach(block => {
     (block as ClassMethodDefBlock).upgrade_0011_to_0012();
+  });
+}
+
+/**
+ * Upgrades the ClassMethodDefBlocks in the given workspace from version 0013 to 0014.
+ * This function should only be called when upgrading old projects.
+ */
+export function upgrade_0013_to_0014(workspace: Blockly.Workspace): void {
+  workspace.getBlocksByType(BLOCK_NAME).forEach(block => {
+    (block as ClassMethodDefBlock).upgrade_0013_to_0014();
   });
 }

--- a/frontend/blocks/mrc_component.ts
+++ b/frontend/blocks/mrc_component.ts
@@ -219,7 +219,7 @@ const COMPONENT = {
   },
   getMechanismInitArgName: function (this: ComponentBlock): string {
     // Return the name of the arg used to represent this component's arguments in a mechanism's
-    // constructor or a mechanism's define_hardware method.
+    // constructor or a mechanism's defineHardware method.
     return getMechanismInitArgName(this.getFieldValue(FIELD_NAME));
   },
   getComponentArgs: function (this: ComponentBlock, args: storageModuleContent.MethodArg[]): void {
@@ -384,7 +384,7 @@ export const pythonFromBlock = function (
     }
   } else {
     // In a mechanism, a component block does not have input sockets.
-    // Each argument of the mechanism's constructor (and the mechanism's define_hardware method) is
+    // Each argument of the mechanism's constructor (and the mechanism's defineHardware method) is
     // a tuple containing the constructor parameters of a component.
     // Use the * operator to unpack the elements of the tuple and pass each
     // element as a separate positional argument to the component constructor.
@@ -413,7 +413,7 @@ export function getAllPossibleComponents(
 }
 
 export function getMechanismInitArgName(componentName: string): string {
-  return componentName + '__args';
+  return componentName + 'Args';
 }
 
 function createComponentBlock(

--- a/frontend/blocks/mrc_event_handler.ts
+++ b/frontend/blocks/mrc_event_handler.ts
@@ -437,7 +437,7 @@ function generateRegisterEventHandler(
   }
   if (fullSender) {
     generator.addRegisterEventHandlerStatement(
-        fullSender + '.register_event_handler(\'' + eventName + '\', self.' + funcName + ')\n');
+        fullSender + '.registerEventHandler(\'' + eventName + '\', self.' + funcName + ')\n');
   }
 }
 

--- a/frontend/blocks/mrc_mechanism.ts
+++ b/frontend/blocks/mrc_mechanism.ts
@@ -510,7 +510,7 @@ export function createMechanismBlock(
     components: storageModuleContent.Component[],
     showSimpleClassNames: boolean): toolboxItems.Block {
   const snakeCaseName = storageNames.pascalCaseToSnakeCase(mechanism.className);
-  const mechanismName = 'my_' + snakeCaseName;
+  const mechanismName = 'my' + mechanism.className;
   const extraState: MechanismExtraState = {
     mechanismModuleId: mechanism.moduleId,
     importModule: snakeCaseName,

--- a/frontend/blocks/mrc_mechanism.ts
+++ b/frontend/blocks/mrc_mechanism.ts
@@ -509,11 +509,11 @@ export function createMechanismBlock(
     mechanism: storageModule.Mechanism,
     components: storageModuleContent.Component[],
     showSimpleClassNames: boolean): toolboxItems.Block {
-  const snakeCaseName = storageNames.pascalCaseToSnakeCase(mechanism.className);
+  const importModule = storageNames.pascalCaseToSnakeCase(mechanism.className);
   const mechanismName = 'my' + mechanism.className;
   const extraState: MechanismExtraState = {
     mechanismModuleId: mechanism.moduleId,
-    importModule: snakeCaseName,
+    importModule: importModule,
     parameters: [],
   };
   const fields: {[key: string]: any} = {};

--- a/frontend/blocks/mrc_mechanism_component_holder.ts
+++ b/frontend/blocks/mrc_mechanism_component_holder.ts
@@ -333,7 +333,7 @@ export const setup = function () {
 }
 
 function pythonFromBlockInRobot(block: MechanismComponentHolderBlock, generator: ExtendedPythonGenerator) {
-  let code = 'def define_hardware(self):\n';
+  let code = 'def defineHardware(self):\n';
 
   const mechanisms = generator.statementToCode(block, INPUT_MECHANISMS);
   const components = generator.statementToCode(block, INPUT_COMPONENTS);
@@ -345,11 +345,11 @@ function pythonFromBlockInRobot(block: MechanismComponentHolderBlock, generator:
     code += generator.INDENT + 'pass\n';
   }
 
-  generator.addClassMethodDefinition('define_hardware', code);
+  generator.addClassMethodDefinition('defineHardware', code);
 }
 
 function pythonFromBlockInMechanism(block: MechanismComponentHolderBlock, generator: ExtendedPythonGenerator) {
-  let code = 'def define_hardware(self';
+  let code = 'def defineHardware(self';
   const mechanismInitArgNames: string[] = generator.getMechanismInitArgNames();
   if (mechanismInitArgNames.length) {
     code += ', ' + mechanismInitArgNames.join(', ');
@@ -362,7 +362,7 @@ function pythonFromBlockInMechanism(block: MechanismComponentHolderBlock, genera
   const allComponents = components + privateComponents;
   if (allComponents) {
     code += allComponents;
-    generator.addClassMethodDefinition('define_hardware', code);
+    generator.addClassMethodDefinition('defineHardware', code);
   }
 }
 
@@ -420,7 +420,7 @@ export function hasAnyComponents(workspace: Blockly.Workspace): boolean {
 }
 
 /**
- * Collects the args for the mechanism's constructor and define_hardware method.
+ * Collects the args for the mechanism's constructor and defineHardware method.
  */
 export function getMechanismInitArgNames(workspace: Blockly.Workspace, mechanismInitArgNames: string[]): void {
   workspace.getBlocksByType(BLOCK_NAME).forEach( block => {

--- a/frontend/blocks/utils/generated/server_python_scripts.json
+++ b/frontend/blocks/utils/generated/server_python_scripts.json
@@ -34,7 +34,7 @@
                         }
                     ],
                     "declaringClassName": "blocks_base_classes.Mechanism",
-                    "functionName": "fire_event",
+                    "functionName": "fireEvent",
                     "returnType": "None",
                     "tooltip": ""
                 },
@@ -47,7 +47,7 @@
                         }
                     ],
                     "declaringClassName": "blocks_base_classes.Mechanism",
-                    "functionName": "opmode_end",
+                    "functionName": "opmodeEnd",
                     "returnType": "None",
                     "tooltip": ""
                 },
@@ -60,7 +60,7 @@
                         }
                     ],
                     "declaringClassName": "blocks_base_classes.Mechanism",
-                    "functionName": "opmode_periodic",
+                    "functionName": "opmodePeriodic",
                     "returnType": "None",
                     "tooltip": ""
                 },
@@ -73,30 +73,7 @@
                         }
                     ],
                     "declaringClassName": "blocks_base_classes.Mechanism",
-                    "functionName": "opmode_start",
-                    "returnType": "None",
-                    "tooltip": ""
-                },
-                {
-                    "args": [
-                        {
-                            "defaultValue": "",
-                            "name": "self",
-                            "type": "blocks_base_classes.Mechanism"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "event_name",
-                            "type": "str"
-                        },
-                        {
-                            "defaultValue": "",
-                            "name": "event_handler",
-                            "type": "typing.Callable"
-                        }
-                    ],
-                    "declaringClassName": "blocks_base_classes.Mechanism",
-                    "functionName": "register_event_handler",
+                    "functionName": "opmodeStart",
                     "returnType": "None",
                     "tooltip": ""
                 },
@@ -119,7 +96,30 @@
                         }
                     ],
                     "declaringClassName": "blocks_base_classes.Mechanism",
-                    "functionName": "unregister_event_handler",
+                    "functionName": "registerEventHandler",
+                    "returnType": "None",
+                    "tooltip": ""
+                },
+                {
+                    "args": [
+                        {
+                            "defaultValue": "",
+                            "name": "self",
+                            "type": "blocks_base_classes.Mechanism"
+                        },
+                        {
+                            "defaultValue": "",
+                            "name": "event_name",
+                            "type": "str"
+                        },
+                        {
+                            "defaultValue": "",
+                            "name": "event_handler",
+                            "type": "typing.Callable"
+                        }
+                    ],
+                    "declaringClassName": "blocks_base_classes.Mechanism",
+                    "functionName": "unregisterEventHandler",
                     "returnType": "None",
                     "tooltip": ""
                 }

--- a/frontend/blocks/utils/python.ts
+++ b/frontend/blocks/utils/python.ts
@@ -50,9 +50,9 @@ export const ROBOT_METHOD_NAMES_OVERRIDEABLE: string[] = [
 
 export const CLASS_NAME_MECHANISM = MODULE_NAME_BLOCKS_BASE_CLASSES + '.Mechanism';
 export const MECHANISM_METHOD_NAMES_OVERRIDEABLE: string[] = [
-  'opmode_end',
-  'opmode_periodic',
-  'opmode_start',
+  'opmodeEnd',
+  'opmodePeriodic',
+  'opmodeStart',
 ];
 
 export const CLASS_NAME_OPMODE = 'wpilib.PeriodicOpMode';

--- a/frontend/blocks/utils/variable.ts
+++ b/frontend/blocks/utils/variable.ts
@@ -63,7 +63,6 @@ export function varNameForType(type: string): string {
   }
 
   // TODO(lizlooney): Should the prefix "my" in myTuple, myDict, myCallable, myArray, and my<type> be localized?
-  // TODO(lizlooney): Should variable names be lowerPascalCase or snake_case?
 
   if (type.startsWith('tuple[') || type.startsWith('Tuple[')) {
     return 'myTuple';

--- a/frontend/editor/extended_python_generator.ts
+++ b/frontend/editor/extended_python_generator.ts
@@ -103,7 +103,7 @@ export class ExtendedPythonGenerator extends PythonGenerator {
   private hasAnyComponents = false;
   private mechanismInitArgNames: string[] = [];
 
-  // Has event handlers (ie, needs to call self.register_event_handlers in __init__)
+  // Has event handlers (ie, needs to call self.registerEventHandlers in __init__)
   private hasAnyEventHandlers = false;
 
   private classMethods: {[key: string]: string} = Object.create(null);
@@ -182,12 +182,12 @@ export class ExtendedPythonGenerator extends PythonGenerator {
     switch (this.getModuleType()) {
       case storageModule.ModuleType.ROBOT:
         initStatements += this.INDENT + 'self.mechanisms = []\n';
-        initStatements += this.INDENT + 'self.event_handlers = {}\n';
-        initStatements += this.INDENT + 'self.define_hardware()\n';
+        initStatements += this.INDENT + 'self.eventHandlers = {}\n';
+        initStatements += this.INDENT + 'self.defineHardware()\n';
         break;
       case storageModule.ModuleType.MECHANISM:
         if (this.hasAnyComponents) {
-          initStatements += this.INDENT + 'self.define_hardware(' +
+          initStatements += this.INDENT + 'self.defineHardware(' +
               this.mechanismInitArgNames.join(', ') + ')\n';
         }
         break;
@@ -197,7 +197,7 @@ export class ExtendedPythonGenerator extends PythonGenerator {
     }
 
     if (this.hasAnyEventHandlers) {
-      initStatements += this.INDENT + "self.register_event_handlers()\n";
+      initStatements += this.INDENT + "self.registerEventHandlers()\n";
     }
 
     return initStatements;
@@ -342,58 +342,58 @@ export class ExtendedPythonGenerator extends PythonGenerator {
       if (this.getModuleType() === storageModule.ModuleType.ROBOT) {
         // Define methods that we use for blocks, but are not in wpilib.OpModeRobot.
         this.fromModuleImportName('typing', 'Callable');
-        this.classMethods['register_event_handler'] = (
-            'def register_event_handler(self, event_name: str, event_handler: Callable) -> None:\n' +
-            this.INDENT + 'if event_name in self.event_handlers:\n' +
-            this.INDENT.repeat(2) + 'self.event_handlers[event_name].append(event_handler)\n' +
+        this.classMethods['registerEventHandler'] = (
+            'def registerEventHandler(self, eventName: str, eventHandler: Callable) -> None:\n' +
+            this.INDENT + 'if eventName in self.eventHandlers:\n' +
+            this.INDENT.repeat(2) + 'self.eventHandlers[eventName].append(eventHandler)\n' +
             this.INDENT + 'else:\n' +
-            this.INDENT.repeat(2) + 'self.event_handlers[event_name] = [event_handler]\n'
+            this.INDENT.repeat(2) + 'self.eventHandlers[eventName] = [eventHandler]\n'
         );
-        this.classMethods['unregister_event_handler'] = (
-            'def unregister_event_handler(self, event_name: str, event_handler: Callable) -> None:\n' +
-            this.INDENT + 'if event_name in self.event_handlers:\n' +
-            this.INDENT.repeat(2) + 'if event_handler in self.event_handlers[event_name]:\n' +
-            this.INDENT.repeat(3) + 'self.event_handlers[event_name].remove(event_handler)\n' +
-            this.INDENT.repeat(3) + 'if not self.event_handlers[event_name]:\n' +
-            this.INDENT.repeat(4) + 'del self.event_handlers[event_name]\n'
+        this.classMethods['unregisterEventHandler'] = (
+            'def unregisterEventHandler(self, eventName: str, eventHandler: Callable) -> None:\n' +
+            this.INDENT + 'if eventName in self.eventHandlers:\n' +
+            this.INDENT.repeat(2) + 'if eventHandler in self.eventHandlers[eventName]:\n' +
+            this.INDENT.repeat(3) + 'self.eventHandlers[eventName].remove(eventHandler)\n' +
+            this.INDENT.repeat(3) + 'if not self.eventHandlers[eventName]:\n' +
+            this.INDENT.repeat(4) + 'del self.eventHandlers[eventName]\n'
         )
-        this.classMethods['fire_event'] = (
-            'def fire_event(self, event_name: str, *args) -> None:\n' +
-            this.INDENT + 'if event_name in self.event_handlers:\n' +
-            this.INDENT.repeat(2) + 'for event_handler in self.event_handlers[event_name]:\n' +
-            this.INDENT.repeat(3) + 'event_handler(*args)\n'
+        this.classMethods['fireEvent'] = (
+            'def fireEvent(self, eventName: str, *args) -> None:\n' +
+            this.INDENT + 'if eventName in self.eventHandlers:\n' +
+            this.INDENT.repeat(2) + 'for eventHandler in self.eventHandlers[eventName]:\n' +
+            this.INDENT.repeat(3) + 'eventHandler(*args)\n'
         )
-        this.classMethods['opmode_start'] = (
-            'def opmode_start(self) -> None:\n' +
+        this.classMethods['opmodeStart'] = (
+            'def opmodeStart(self) -> None:\n' +
             this.INDENT + 'for mechanism in self.mechanisms:\n' +
-            this.INDENT.repeat(2) + 'mechanism.opmode_start()\n'
+            this.INDENT.repeat(2) + 'mechanism.opmodeStart()\n'
         );
-        this.classMethods['opmode_periodic'] = (
-            'def opmode_periodic(self) -> None:\n' +
+        this.classMethods['opmodePeriodic'] = (
+            'def opmodePeriodic(self) -> None:\n' +
             this.INDENT + 'for mechanism in self.mechanisms:\n' +
-            this.INDENT.repeat(2) + 'mechanism.opmode_periodic()\n'
+            this.INDENT.repeat(2) + 'mechanism.opmodePeriodic()\n'
         );
-        this.classMethods['opmode_end'] = (
-            'def opmode_end(self) -> None:\n' +
+        this.classMethods['opmodeEnd'] = (
+            'def opmodeEnd(self) -> None:\n' +
             this.INDENT + 'for mechanism in self.mechanisms:\n' +
-            this.INDENT.repeat(2) + 'mechanism.opmode_end()\n'
+            this.INDENT.repeat(2) + 'mechanism.opmodeEnd()\n'
         );
       }
 
       if (this.getModuleType() === storageModule.ModuleType.OPMODE) {
-        // Add code to the Start method to call robot.opmode_start.
-        this.classMethods[START_METHOD_NAME] = this.insertCodeToCallRobot(START_METHOD_NAME, 'opmode_start');
+        // Add code to the Start method to call robot.opmodeStart.
+        this.classMethods[START_METHOD_NAME] = this.insertCodeToCallRobot(START_METHOD_NAME, 'opmodeStart');
 
-        // Add code to the periodic method to call robot.opmode_periodic.
-        let periodicCode = this.insertCodeToCallRobot(PERIODIC_METHOD_NAME, 'opmode_periodic');
+        // Add code to the periodic method to call robot.opmodePeriodic.
+        let periodicCode = this.insertCodeToCallRobot(PERIODIC_METHOD_NAME, 'opmodePeriodic');
         if (STEPS_METHOD_NAME in this.classMethods) {
           // Generate code to call the steps method after the user's code.
           periodicCode += this.INDENT + `self.${STEPS_METHOD_NAME}()\n`;
         }
         this.classMethods[PERIODIC_METHOD_NAME] = periodicCode;
 
-        // Add code to the End method to call robot.opmode_end.
-        this.classMethods[END_METHOD_NAME] = this.insertCodeToCallRobot(END_METHOD_NAME, 'opmode_end');
+        // Add code to the End method to call robot.opmodeEnd.
+        this.classMethods[END_METHOD_NAME] = this.insertCodeToCallRobot(END_METHOD_NAME, 'opmodeEnd');
       }
 
       const classMethods = [];
@@ -403,14 +403,14 @@ export class ExtendedPythonGenerator extends PythonGenerator {
         classMethods.push(this.classMethods['__init__'])
       }
 
-      // Generate the define_hardware method next.
-      if ('define_hardware' in this.classMethods) {
-        classMethods.push(this.classMethods['define_hardware'])
+      // Generate the defineHardware method next.
+      if ('defineHardware' in this.classMethods) {
+        classMethods.push(this.classMethods['defineHardware'])
       }
 
-      // Generate the register_event_handlers method next.
+      // Generate the registerEventHandlers method next.
       if (this.registerEventHandlerStatements && this.registerEventHandlerStatements.length > 0) {
-        let registerEventHandlers = 'def register_event_handlers(self):\n';
+        let registerEventHandlers = 'def registerEventHandlers(self):\n';
         for (const registerEventHandlerStatement of this.registerEventHandlerStatements) {
           registerEventHandlers += this.INDENT + registerEventHandlerStatement;
         }
@@ -419,7 +419,7 @@ export class ExtendedPythonGenerator extends PythonGenerator {
 
       // Generate the remaining methods.
       for (const name in this.classMethods) {
-        if (name === '__init__' || name === 'define_hardware') {
+        if (name === '__init__' || name === 'defineHardware') {
           continue;
         }
         classMethods.push(this.classMethods[name])

--- a/frontend/modules/mechanism_start.json
+++ b/frontend/modules/mechanism_start.json
@@ -33,7 +33,7 @@
                     "params": []
                 },
                 "fields": {
-                    "NAME": "opmode_periodic"
+                    "NAME": "opmodePeriodic"
                 }
             },
             {

--- a/frontend/storage/upgrade_project.ts
+++ b/frontend/storage/upgrade_project.ts
@@ -33,7 +33,8 @@ import {
     upgrade_004_to_005,
     upgrade_006_to_007,
     upgrade_007_to_008,
-    upgrade_0011_to_0012 as upgrade_class_method_def_0011_to_0012
+    upgrade_0011_to_0012 as upgrade_class_method_def_0011_to_0012,
+    upgrade_0013_to_0014 as upgrade_class_method_def_0013_to_0014
     } from '../blocks/mrc_class_method_def';
 import { upgrade_005_to_006 } from '../blocks/mrc_component';
 import {
@@ -50,7 +51,7 @@ import { GamepadTypeUtils } from '../types/GamepadType';
 import * as workspaces from '../blocks/utils/workspaces';
 
 export const NO_VERSION = '0.0.0';
-export const CURRENT_VERSION = '0.0.13';
+export const CURRENT_VERSION = '0.0.14';
 
 export async function upgradeProjectIfNecessary(
     storage: commonStorage.Storage, projectName: string): Promise<void> {
@@ -124,6 +125,11 @@ export async function upgradeProjectIfNecessary(
       // @ts-ignore
       case '0.0.12':
         await upgradeFrom_0012_to_0013(storage, projectName, projectInfo);
+
+      // Intentional fallthrough after case '0.0.13'
+      // @ts-ignore
+      case '0.0.13':
+        await upgradeFrom_0013_to_0014(storage, projectName, projectInfo);
 
     }
     await storageProject.saveProjectInfo(storage, projectName, projectInfo);
@@ -391,4 +397,18 @@ async function upgradeFrom_0012_to_0013(
       noModuleTypes, noPreupgrade,
       anyModuleType, upgrade);
   projectInfo.version = '0.0.13';
+}
+
+async function upgradeFrom_0013_to_0014(
+    storage: commonStorage.Storage,
+    projectName: string,
+    projectInfo: storageProject.ProjectInfo): Promise<void> {
+  // mrc_class_method_def blocks for mechanism 'opmode_start' method need to be changed to 'opmodeStart'.
+  // mrc_class_method_def blocks for mechanism 'opmode_periodic' method need to be changed to 'opmodePeriodic'.
+  // mrc_class_method_def blocks for mechanism 'opmode_end' method need to be changed to 'opmodeEnd'.
+  await upgradeBlocksFiles(
+      storage, projectName,
+      noModuleTypes, noPreupgrade,
+      isMechanism, upgrade_class_method_def_0013_to_0014);
+  projectInfo.version = '0.0.14';
 }

--- a/frontend/toolbox/event_category.ts
+++ b/frontend/toolbox/event_category.ts
@@ -64,7 +64,7 @@ class EventsCategory {
     // Add a block that lets the user define a new event.
     contents.push(
         new toolboxItems.Label(Blockly.Msg['CUSTOM_EVENTS_LABEL']),
-        createCustomEventBlock(storageNames.makeUniqueName('my_event', eventNames)));
+        createCustomEventBlock(storageNames.makeUniqueName('myEvent', eventNames)));
 
     // Get blocks for firing events defined in the current workspace.
     addFireEventBlocks(eventsFromWorkspace, contents);

--- a/python_tools/json_util.py
+++ b/python_tools/json_util.py
@@ -497,7 +497,7 @@ class JsonGenerator:
 
     if declaring_class_name == 'wpilib.ExpansionHubMotor':
       args = []
-      args.append(self._createArgData('expansion_hub_motor', 'SYSTEMCORE_USB_PORT__EXPANSION_HUB_MOTOR_PORT'))
+      args.append(self._createArgData('expansionHubMotor', 'SYSTEMCORE_USB_PORT__EXPANSION_HUB_MOTOR_PORT'))
       constructor_data[_KEY_COMPONENT_ARGS] = args
       constructor_data[_KEY_IS_COMPONENT] = True
       class_data[_KEY_IS_COMPONENT] = True
@@ -505,7 +505,7 @@ class JsonGenerator:
 
     if declaring_class_name == 'wpilib.ExpansionHubServo':
       args = []
-      args.append(self._createArgData('expansion_hub_servo', 'SYSTEMCORE_USB_PORT__EXPANSION_HUB_SERVO_PORT'))
+      args.append(self._createArgData('expansionHubServo', 'SYSTEMCORE_USB_PORT__EXPANSION_HUB_SERVO_PORT'))
       constructor_data[_KEY_COMPONENT_ARGS] = args
       constructor_data[_KEY_IS_COMPONENT] = True
       class_data[_KEY_IS_COMPONENT] = True
@@ -513,7 +513,7 @@ class JsonGenerator:
 
     if declaring_class_name == 'wpilib.AddressableLED':
       args = []
-      args.append(self._createArgData('smart_io_port', 'SYSTEMCORE_SMART_IO_PORT'))
+      args.append(self._createArgData('smartIoPort', 'SYSTEMCORE_SMART_IO_PORT'))
       constructor_data[_KEY_COMPONENT_ARGS] = args
       constructor_data[_KEY_IS_COMPONENT] = True
       class_data[_KEY_IS_COMPONENT] = True
@@ -526,9 +526,9 @@ class JsonGenerator:
           arg_names[2] == 'fullRange' and
           arg_names[3] == 'expectedZero'):
         args = []
-        args.append(self._createArgData('smart_io_port', 'SYSTEMCORE_SMART_IO_PORT'))
-        args.append(self._createArgData('full_range', self._getClassName(arg_types[2]), '1.0'))
-        args.append(self._createArgData('expected_zero', self._getClassName(arg_types[3]), '0.0'))
+        args.append(self._createArgData('smartIoPort', 'SYSTEMCORE_SMART_IO_PORT'))
+        args.append(self._createArgData(arg_names[2], self._getClassName(arg_types[2]), '1.0'))
+        args.append(self._createArgData(arg_names[3], self._getClassName(arg_types[3]), '0.0'))
         constructor_data[_KEY_COMPONENT_ARGS] = args
         constructor_data[_KEY_COMPONENT_ARGS]
         constructor_data[_KEY_IS_COMPONENT] = True
@@ -542,9 +542,9 @@ class JsonGenerator:
           arg_names[2] == 'fullRange' and
           arg_names[3] == 'offset'):
         args = []
-        args.append(self._createArgData('smart_io_port', 'SYSTEMCORE_SMART_IO_PORT'))
-        args.append(self._createArgData('full_range', self._getClassName(arg_types[2]), arg_default_values[2]))
-        args.append(self._createArgData('offset', self._getClassName(arg_types[3]), arg_default_values[3]))
+        args.append(self._createArgData('smartIoPort', 'SYSTEMCORE_SMART_IO_PORT'))
+        args.append(self._createArgData(arg_names[2], self._getClassName(arg_types[2]), arg_default_values[2]))
+        args.append(self._createArgData(arg_names[3], self._getClassName(arg_types[3]), arg_default_values[3]))
         constructor_data[_KEY_COMPONENT_ARGS] = args
         constructor_data[_KEY_IS_COMPONENT] = True
         class_data[_KEY_IS_COMPONENT] = True
@@ -552,7 +552,7 @@ class JsonGenerator:
 
     if declaring_class_name == 'wpilib.DigitalInput':
       args = []
-      args.append(self._createArgData('smart_io_port', 'SYSTEMCORE_SMART_IO_PORT'))
+      args.append(self._createArgData('smartIoPort', 'SYSTEMCORE_SMART_IO_PORT'))
       constructor_data[_KEY_COMPONENT_ARGS] = args
       constructor_data[_KEY_IS_COMPONENT] = True
       class_data[_KEY_IS_COMPONENT] = True
@@ -565,9 +565,9 @@ class JsonGenerator:
           arg_names[2] == 'fullRange' and
           arg_names[3] == 'expectedZero'):
         args = []
-        args.append(self._createArgData('smart_io_port', 'SYSTEMCORE_SMART_IO_PORT'))
-        args.append(self._createArgData('full_range', self._getClassName(arg_types[2]), '1'))
-        args.append(self._createArgData('expected_zero', self._getClassName(arg_types[3]), '0'))
+        args.append(self._createArgData('smartIoPort', 'SYSTEMCORE_SMART_IO_PORT'))
+        args.append(self._createArgData(arg_names[2], self._getClassName(arg_types[2]), '1'))
+        args.append(self._createArgData(arg_names[3], self._getClassName(arg_types[3]), '0'))
         constructor_data[_KEY_COMPONENT_ARGS] = args
         constructor_data[_KEY_IS_COMPONENT] = True
         class_data[_KEY_IS_COMPONENT] = True
@@ -578,7 +578,7 @@ class JsonGenerator:
           arg_names[0] == 'self' and
           arg_names[1] == 'mountOrientation'):
         args = []
-        args.append(self._createArgData('mount_orientation', self._getClassName(arg_types[1]), arg_default_values[1]))
+        args.append(self._createArgData(arg_names[1], self._getClassName(arg_types[1]), arg_default_values[1]))
         constructor_data[_KEY_COMPONENT_ARGS] = args
         constructor_data[_KEY_IS_COMPONENT] = True
         class_data[_KEY_IS_COMPONENT] = True
@@ -586,7 +586,7 @@ class JsonGenerator:
 
     if declaring_class_name ==  'wpilib.PWMSparkMax':
       args = []
-      args.append(self._createArgData('smart_io_port', 'SYSTEMCORE_SMART_IO_PORT'))
+      args.append(self._createArgData('smartIoPort', 'SYSTEMCORE_SMART_IO_PORT'))
       constructor_data[_KEY_COMPONENT_ARGS] = args
       constructor_data[_KEY_IS_COMPONENT] = True
       class_data[_KEY_IS_COMPONENT] = True

--- a/runtime_python/blocks_base_classes/mechanism.py
+++ b/runtime_python/blocks_base_classes/mechanism.py
@@ -4,32 +4,32 @@ from typing import Callable
 
 class Mechanism:
     def __init__(self):
-        # In self.event_handlers, the keys are the event names, the values are a list of handlers.
-        self.event_handlers = {}
+        # In self.eventHandlers, the keys are the event names, the values are a list of handlers.
+        self.eventHandlers = {}
 
-    def register_event_handler(self, event_name: str, event_handler: Callable) -> None:
-        if event_name in self.event_handlers:
-            self.event_handlers[event_name].append(event_handler)
+    def registerEventHandler(self, eventName: str, eventHandler: Callable) -> None:
+        if eventName in self.eventHandlers:
+            self.eventHandlers[eventName].append(eventHandler)
         else:
-            self.event_handlers[event_name] = [event_handler]
+            self.eventHandlers[eventName] = [eventHandler]
 
-    def unregister_event_handler(self, event_name: str, event_handler: Callable) -> None:
-        if event_name in self.event_handlers:
-            if event_handler in self.event_handlers[event_name]:
-                self.event_handlers[event_name].remove(event_handler)
-                if not self.event_handlers[event_name]:
-                    del self.event_handlers[event_name]
+    def unregisterEventHandler(self, eventName: str, eventHandler: Callable) -> None:
+        if eventName in self.eventHandlers:
+            if eventHandler in self.eventHandlers[eventName]:
+                self.eventHandlers[eventName].remove(eventHandler)
+                if not self.eventHandlers[eventName]:
+                    del self.eventHandlers[eventName]
 
-    def fire_event(self, event_name: str, *args) -> None:
-        if event_name in self.event_handlers:
-            for event_handler in self.event_handlers[event_name]:
-                event_handler(*args)
+    def fireEvent(self, eventName: str, *args) -> None:
+        if eventName in self.eventHandlers:
+            for eventHandler in self.eventHandlers[eventName]:
+                eventHandler(*args)
 
-    def opmode_start(self) -> None:
+    def opmodeStart(self) -> None:
         pass
 
-    def opmode_periodic(self) -> None:
+    def opmodePeriodic(self) -> None:
         pass
 
-    def opmode_end(self) -> None:
+    def opmodeEnd(self) -> None:
         pass


### PR DESCRIPTION
Use camelCase instead of snake_case for:
- robot variables, methods, and arguments
- component constructor arguments
- mechanism variables, methods, and arguments
- default mechanism name
- default name when creating a new event
- default name when creating a new method

I ran through the checklist and I tested a project on my systemcore.