### PR TITLE
Fix to only show create button when a create

### DIFF
--- a/frontend/reactComponents/ProjectManageModal.tsx
+++ b/frontend/reactComponents/ProjectManageModal.tsx
@@ -491,6 +491,7 @@ export default function ProjectManageModal(props: ProjectManageModalProps): Reac
             setNewItemName={setNewItemName}
             onAddNewItem={handleAddNewItem}
             projectNames={allProjectNames}
+            showCreateButton={true}
           />
         </div>
       </Antd.Modal>

--- a/frontend/reactComponents/ProjectNameComponent.tsx
+++ b/frontend/reactComponents/ProjectNameComponent.tsx
@@ -29,6 +29,7 @@ interface ProjectNameComponentProps {
   setNewItemName: (name: string) => void;
   onAddNewItem: () => void;
   projectNames: string[];
+  showCreateButton?: boolean;
 }
 
 /** Full width style for input components. */
@@ -151,7 +152,7 @@ export default function ProjectNameComponent(props: ProjectNameComponentProps): 
       </Antd.Typography.Paragraph>
       <Antd.Space.Compact style={FULL_WIDTH_STYLE}>
         {renderInput()}
-        {renderButton()}
+        {props.showCreateButton && renderButton()}
       </Antd.Space.Compact>
       {renderErrorAlert()}
     </>


### PR DESCRIPTION
Now renaming or copying a project doesn't show the confusing "Create" button in addition to the buttons on the bottom.

