### PR TITLE
Make input have keyboard focus when add tab dialog is opened

### DIFF
--- a/frontend/reactComponents/AddTabDialog.tsx
+++ b/frontend/reactComponents/AddTabDialog.tsx
@@ -62,6 +62,7 @@ export default function AddTabDialog(props: AddTabDialogProps) {
   const tabType = props.initialType ?? TabType.OPMODE;
   const [availableItems, setAvailableItems] = React.useState<Module[]>([]);
   const [newItemName, setNewItemName] = React.useState('');
+  const inputRef = React.useRef<Antd.InputRef>(null);
 
   React.useEffect(() => {
     if (!props.project) {
@@ -136,6 +137,7 @@ export default function AddTabDialog(props: AddTabDialogProps) {
       open={props.isOpen}
       onCancel={props.onCancel}
       footer={null}
+      afterOpenChange={(open) => { if (open) inputRef.current?.focus(); }}
     >
       <div style={{marginTop: 16}}>
         <h4 style={{margin: '0 0 8px 0'}}>
@@ -211,6 +213,7 @@ export default function AddTabDialog(props: AddTabDialogProps) {
             project={props.project}
             storage={props.storage}
             buttonLabel={t('CREATE')}
+            inputRef={inputRef}
           />
         </div>
       </div>

--- a/frontend/reactComponents/ClassNameComponent.tsx
+++ b/frontend/reactComponents/ClassNameComponent.tsx
@@ -37,6 +37,7 @@ interface ClassNameComponentProps {
   project: storageProject.Project | null;
   storage: commonStorage.Storage | null;
   buttonLabel: string;
+  inputRef?: React.Ref<Antd.InputRef>;
 }
 
 /** Width calculation for input when button is present. */
@@ -134,6 +135,7 @@ export default function ClassNameComponent(props: ClassNameComponentProps): Reac
   /** Renders the input field. */
   const renderInput = (): React.JSX.Element => (
     <Antd.Input
+      ref={props.inputRef}
       style={{width: getInputWidth()}}
       value={props.newItemName}
       onChange={handleInputChange}


### PR DESCRIPTION
This simply makes it so that if you press the add button on the tabs (either row), the input is where you type in the new name (as expected) 

Fixes #407 