### PR TITLE
Add rumble support for gamepads

### DIFF
--- a/frontend/blocks/mrc_gamepad_rumble.ts
+++ b/frontend/blocks/mrc_gamepad_rumble.ts
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright 2026 Porpoiseful LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview A block for interfacing with the gamepad rumble
+ * @author alan@porpoiseful.com (Alan Smith)
+ */
+
+/* NOTE: This will likely go away when we can parse the gamepad class
+ * but it doesn't exist yet, so this is a placeholder.
+ */
+
+import * as Blockly from 'blockly/core';
+import { PythonGenerator } from 'blockly/python';
+import { MRC_STYLE_DRIVER_STATION } from '../themes/styles';
+import * as Gamepad from '../fields/field_gamepads';
+
+export const BLOCK_NAME = 'mrc_gamepad_rumble';
+
+export const setup = function() {
+  Blockly.Blocks[BLOCK_NAME] = {
+    init: function() {
+      this.appendDummyInput()
+          .appendField(Gamepad.createTitleField())
+          .appendField(Gamepad.createPortField(true), Gamepad.PORT_FIELD_NAME)
+          .appendField(Gamepad.createRumbleField(), Gamepad.RUMBLE_FIELD_NAME)
+          .appendField(Blockly.Msg.TO)
+          .appendField(new Blockly.FieldNumber(1, 0, 1, 0.1), Blockly.Msg.VALUE);
+      this.setOutput(false);
+      this.setPreviousStatement(true, null);
+      this.setNextStatement(true, null);
+      this.setStyle(MRC_STYLE_DRIVER_STATION);
+    },
+  };
+};
+
+export const pythonFromBlock = function(
+    block: Blockly.Block,
+    _: PythonGenerator,
+) {
+  let result = Gamepad.methodForRumble(
+    block.getFieldValue(Gamepad.PORT_FIELD_NAME),
+    block.getFieldValue(Gamepad.RUMBLE_FIELD_NAME), 
+    block.getFieldValue(Blockly.Msg.VALUE));
+  
+  return result;
+}

--- a/frontend/blocks/setup_custom_blocks.ts
+++ b/frontend/blocks/setup_custom_blocks.ts
@@ -24,6 +24,7 @@ import * as JumpToStep from './mrc_jump_to_step';
 import * as GamepadBoolean from './mrc_gamepad_boolean';
 import * as GamepadAnalog from './mrc_gamepad_analog';
 import * as GamepadBooleanEvent from './mrc_gamepad_boolean_event';
+import * as GamepadRumble from './mrc_gamepad_rumble';
 
 const customBlocks = [
   CallPythonFunction,
@@ -51,6 +52,7 @@ const customBlocks = [
   GamepadBoolean,
   GamepadAnalog,
   GamepadBooleanEvent,
+  GamepadRumble
 ];
 
 export const setup = function(forBlock: any) {

--- a/frontend/fields/field_gamepads.ts
+++ b/frontend/fields/field_gamepads.ts
@@ -44,6 +44,7 @@ export const BUTTON_FIELD_NAME = 'GAMEPAD_BUTTON';
 export const ACTION_FIELD_NAME = 'GAMEPAD_ACTION';
 export const AXIS_FIELD_NAME = 'GAMEPAD_AXIS';
 export const EVENT_FIELD_NAME = 'GAMEPAD_EVENT';
+export const RUMBLE_FIELD_NAME = 'GAMEPAD_RUMBLE';
 
 const ACTION_CONFIG = new Map([
     ['IS_DOWN', { display: () => Blockly.Msg['GAMEPAD_IS_DOWN'], suffix: '' }],
@@ -62,7 +63,7 @@ export function createTitleField(): Blockly.Field {
     return new Blockly.FieldLabel(Blockly.Msg['GAMEPAD']);   
 }
 
-export function createPortField(): Blockly.FieldDropdown {
+export function createPortField(onlyWithRumble: boolean = false): Blockly.FieldDropdown {
     return new Blockly.FieldDropdown(function(this: Blockly.FieldDropdown): Blockly.MenuOption[] {
         const options: Blockly.MenuOption[] = [];
 
@@ -70,6 +71,9 @@ export function createPortField(): Blockly.FieldDropdown {
         for (let port = MIN_GAMEPAD_PORT; port <= MAX_GAMEPAD_PORT; port++) {
             const gamepadType = GamepadTypeUtils.getGamepad(port, currentGamepadConfig);
             if (gamepadType !== GamepadType.NONE) {
+                if (onlyWithRumble && !GamepadTypeUtils.getRumbleConfig(gamepadType)) {
+                    continue;
+                }
                 const portStr = port.toString();
                 options.push([portStr, portStr]);
             }
@@ -538,12 +542,233 @@ export class FieldGamepadAxisDropdown extends Blockly.FieldDropdown {
   }
 }
 
+/**
+ * A dropdown field for gamepad rumble motors that automatically updates its options
+ * based on the selected gamepad port. When the port changes, the rumble options
+ * update to match the capabilities of the newly selected gamepad type.
+ */
+export class FieldGamepadRumbleDropdown extends Blockly.FieldDropdown {
+  /**
+   * Contains data used by this dropdown field's menu generator.
+   * This is public so that the GamepadDropdownOptionsChange event can
+   * update it while undoing/redoing.
+   */
+  dependencyData: DependencyData;
+
+  /** The name of the field that determines this field's options. */
+  private parentName: string;
+
+  /**
+   * Constructs a new FieldGamepadRumbleDropdown.
+   *
+   * @param parentName The name of the parent field whose value determines this
+   *    field's available options. Defaults to PORT_FIELD_NAME.
+   * @param validator An optional function that is called to validate changes to
+   *    this field's value.
+   * @param config An optional map of general options used to configure the
+   *    field, such as a tooltip.
+   */
+  constructor(
+    parentName: string = PORT_FIELD_NAME,
+    validator?: Blockly.FieldValidator,
+    config?: Blockly.FieldConfig,
+  ) {
+    const dependencyData: DependencyData = {};
+
+    // A menu option generator function for this child field that reads the
+    // derived options in the dependency data if available.
+    const menuGenerator: Blockly.MenuGeneratorFunction = () => {
+      // If derivedOptions has been initialized, use that.
+      if (dependencyData.derivedOptions) {
+        return dependencyData.derivedOptions;
+      }
+
+      // Fall back on the options corresponding to the parent field's current value.
+      if (dependencyData.parentField) {
+        const portValue = dependencyData.parentField.getValue();
+        if (portValue) {
+          const port = Number(portValue);
+          const gamepadType = GamepadTypeUtils.getGamepad(port, currentGamepadConfig);
+          const rumbleConfig = GamepadTypeUtils.getRumbleConfig(gamepadType);
+          if (rumbleConfig) {
+            const options: Blockly.MenuOption[] = [];
+            for (const [key, configItem] of rumbleConfig.entries()) {
+              options.push([configItem.display(), key]);
+            }
+            if (options.length > 0) {
+              return options;
+            }
+          }
+        }
+      }
+
+      // Fall back on basic default options.
+      return [['---', '---']];
+    };
+
+    super(menuGenerator, validator, config);
+    this.parentName = parentName;
+    this.dependencyData = dependencyData;
+  }
+
+  /**
+   * Constructs a FieldGamepadRumbleDropdown from a JSON arg object.
+   *
+   * @param options A JSON object with optional "parentName" property.
+   * @returns The new field instance.
+   */
+  static fromJson(options: any): FieldGamepadRumbleDropdown {
+    return new FieldGamepadRumbleDropdown(
+      options['parentName'],
+      undefined,
+      options,
+    );
+  }
+
+  /**
+   * Attach this field to a block.
+   *
+   * @param block The block containing this field.
+   */
+  setSourceBlock(block: Blockly.Block) {
+    super.setSourceBlock(block);
+
+    const parentField: Blockly.Field<string> | null = block.getField(
+      this.parentName,
+    );
+
+    if (!parentField) {
+      throw new Error(
+        'Could not find a parent field with the name ' +
+          this.parentName +
+          ' for the gamepad rumble dropdown.',
+      );
+    }
+
+    this.dependencyData.parentField = parentField;
+
+    const oldValidator = parentField.getValidator();
+
+    // A validator function for the parent field that has the side effect of
+    // updating the options of this child dropdown field based on the new value
+    // of the parent field whenever it changes.
+    parentField.setValidator((newValue) => {
+      if (oldValidator) {
+        const validatedValue = oldValidator(newValue);
+        // If a validator returns null, that means the new value is invalid and
+        // the change should be canceled.
+        if (validatedValue === null) {
+          return null;
+        }
+        // If a validator returns undefined, that means no change. Otherwise,
+        // use the returned value as the new value.
+        if (validatedValue !== undefined) {
+          newValue = validatedValue;
+        }
+      }
+      this.updateOptionsBasedOnNewValue(newValue);
+      return newValue;
+    });
+    this.updateOptionsBasedOnNewValue(parentField.getValue() ?? undefined);
+  }
+
+  /**
+   * Updates the options of this child dropdown field based on the new value of
+   * the parent field.
+   *
+   * @param newValue The newly assigned port value.
+   */
+  private updateOptionsBasedOnNewValue(newValue: string | undefined): void {
+    if (newValue == undefined) {
+      return;
+    }
+
+    const block = this.getSourceBlock();
+    if (!block) {
+      throw new Error(
+        'Could not validate a field that is not attached to a block: ' +
+          this.name,
+      );
+    }
+
+    const port = Number(newValue);
+    const gamepadType = GamepadTypeUtils.getGamepad(port, currentGamepadConfig);
+    const rumbleConfig = GamepadTypeUtils.getRumbleConfig(gamepadType);
+
+    const oldChildValue = this.getValue();
+    const oldChildOptions = this.getOptions(false);
+    let newChildOptions: Blockly.MenuOption[] = [];
+
+    if (rumbleConfig) {
+      for (const [key, configItem] of rumbleConfig.entries()) {
+        newChildOptions.push([configItem.display(), key]);
+      }
+    }
+
+    // If no options available, use placeholder
+    if (newChildOptions.length === 0) {
+      newChildOptions = [['---', '---']];
+    }
+
+    // If the child field's value is still available in the new options, keep
+    // it, otherwise change the field's value to the first available option.
+    const newOptionsIncludeOldValue =
+      newChildOptions.find((option) => option[1] == oldChildValue) != undefined;
+    const newChildValue = newOptionsIncludeOldValue
+      ? oldChildValue
+      : newChildOptions[0][1];
+
+    // Record the options so that the option generator can access them.
+    this.dependencyData.derivedOptions = newChildOptions;
+
+    // Re-run the option generator to update the options on the dropdown.
+    this.getOptions(false);
+
+    // Update this child field's value without broadcasting the normal change
+    // event. The normal value change event can't be properly undone, because
+    // the old value may not be one of the currently valid options, so a custom
+    // change event will be broadcast instead that handles swapping the options
+    // and the value at the same time.
+    Blockly.Events.disable();
+    this.setValue(newChildValue);
+    Blockly.Events.enable();
+
+    if (Blockly.Events.getRecordUndo()) {
+      if (!Blockly.Events.getGroup()) {
+        // Start a change group before the change event. The change event for
+        // the parent field value will be created after this function returns
+        // and will be part of the same group.
+        Blockly.Events.setGroup(true);
+        // Clear the change group later, after all related events have been
+        // broadcast, but before the user performs any more actions.
+        setTimeout(() => Blockly.Events.setGroup(false));
+      }
+
+      // Record that the child field's options and value have changed.
+      Blockly.Events.fire(
+        new GamepadDropdownOptionsChange(
+          block,
+          this.name,
+          oldChildValue ?? undefined,
+          newChildValue ?? undefined,
+          oldChildOptions,
+          newChildOptions,
+        ),
+      );
+    }
+  }
+}
+
 export function createButtonField(): Blockly.Field {
     return new FieldGamepadButtonDropdown();
 }
 
 export function createAnalogAxisField(): Blockly.Field {
     return new FieldGamepadAxisDropdown();
+}
+
+export function createRumbleField(): Blockly.Field {
+    return new FieldGamepadRumbleDropdown();
 }
 
 export function createActionField(): Blockly.Field {
@@ -590,6 +815,16 @@ export function methodForAxis(gamepad: number, axis: string): string {
         (axisConfig?.get(axis)?.method ?? '') + '()';
 }
 
+export function methodForRumble(gamepad: number, rumble: string, value : number): string {
+    const gamepadType = GamepadTypeUtils.getGamepad(gamepad, currentGamepadConfig);
+    
+    // Get the rumble configuration for this gamepad type
+    const rumbleConfig = GamepadTypeUtils.getRumbleConfig(gamepadType);
+    
+    return getGamepad(gamepad) + '.setRumble(' +
+        (rumbleConfig?.get(rumble)?.rumbleType ?? '') + ', ' + value + ')\n';
+}
+
 // Register field types with Blockly
 Blockly.fieldRegistry.register(
   'field_gamepad_button_dropdown',
@@ -599,4 +834,9 @@ Blockly.fieldRegistry.register(
 Blockly.fieldRegistry.register(
   'field_gamepad_axis_dropdown',
   FieldGamepadAxisDropdown,
+);
+
+Blockly.fieldRegistry.register(
+  'field_gamepad_rumble_dropdown',
+  FieldGamepadRumbleDropdown,
 );

--- a/frontend/toolbox/driver_station_category.ts
+++ b/frontend/toolbox/driver_station_category.ts
@@ -5,6 +5,7 @@ import { Editor } from '../editor/editor';
 import { BLOCK_NAME as MRC_CALL_PYTHON_FUNCTION } from '../blocks/mrc_call_python_function';
 import { BLOCK_NAME as MRC_GAMEPAD_BOOLEAN  } from '../blocks/mrc_gamepad_boolean';
 import { BLOCK_NAME as MRC_GAMEPAD_ANALOG  } from '../blocks/mrc_gamepad_analog';
+import { BLOCK_NAME as MRC_GAMEPAD_RUMBLE  } from '../blocks/mrc_gamepad_rumble';
 
 // import { BLOCK_NAME as MRC_GAMEPAD_BOOLEAN_EVENT  } from '../blocks/mrc_gamepad_boolean_event';
 
@@ -57,6 +58,7 @@ function getDriverStationGamepadsCategory(_editor: Editor): toolboxItems.Categor
                 ),
                 new toolboxItems.Block(MRC_GAMEPAD_BOOLEAN, null, null, null),
                 new toolboxItems.Block(MRC_GAMEPAD_ANALOG, null, null, null),
+                new toolboxItems.Block(MRC_GAMEPAD_RUMBLE, null, null, null),
                 // TODO: Add events back here when we figure out how the code will be generated
                 //new toolboxItems.Label("Events"),
                 //new toolboxItems.Block(MRC_GAMEPAD_BOOLEAN_EVENT, null, null, null),


### PR DESCRIPTION
This PR adds the rumble support for gamepads.  It keeps track of knowing which gamepad configurations support rumble.  It only has a single setRumble which has to be called for each rumble type and again to stop it.
