### PR TITLE
Change to released version robotpy installer

### DIFF
--- a/.github/workflows/makeRelease.yml
+++ b/.github/workflows/makeRelease.yml
@@ -1,0 +1,33 @@
+name: MakeRelease
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build package
+        run: npm run package
+
+      - name: Create GitHub release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            --title "Release ${{ github.ref_name }}" \
+            --generate-notes \
+            packaging/*.ipk

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -1,2 +1,0 @@
-To get build cache to work, you need to create a venv in packaging and add robotpy_installer to it.
-Until it gets merged in, you need to be working from this PR: https://github.com/robotpy/robotpy-installer/pull/165 

--- a/packaging/buildCache.sh
+++ b/packaging/buildCache.sh
@@ -23,6 +23,8 @@ if [ -d "$CACHE_DIR" ] && [ "$(ls "$PIP_CACHE_DIR"/*.whl 2>/dev/null | wc -l)" -
     exit 0
 fi
 
+"$SCRIPT_DIR/ensure_venv.sh"
+
 source "$SCRIPT_DIR/venv/bin/activate"
 robotpy installer download-python --cache-root "$CACHE_DIR"
 robotpy installer download robotpy --cache-root "$CACHE_DIR"

--- a/packaging/buildVenv.sh
+++ b/packaging/buildVenv.sh
@@ -9,6 +9,8 @@ SITE_PACKAGES="$VENV_DIR/lib/python${PYTHON_VER}/site-packages"
 VENV_BIN="$VENV_DIR/bin"
 INSTALLER_SRC="$HOME/Projects/mrc-work/robotpy-installer"
 
+"$SCRIPT_DIR/ensure_venv.sh"
+
 echo "Cleaning previous venv..."
 rm -rf "$VENV_DIR"
 mkdir -p "$SITE_PACKAGES"

--- a/packaging/ensure_venv.sh
+++ b/packaging/ensure_venv.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [ ! -d "$SCRIPT_DIR/venv" ]; then
+    echo "Creating packaging venv..."
+    python3 -m venv "$SCRIPT_DIR/venv"
+    "$SCRIPT_DIR/venv/bin/pip" install "robotpy-installer==2027.0.0a7"
+fi


### PR DESCRIPTION
This changes to use the released robotpy-installer, removing some hacky steps, and also making it so we can get github to create releases for us.