### PR TITLE
Use server storage

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -133,8 +133,10 @@ def serve_static(path: str) -> Union[Response, Tuple[Response, int]]:
         except:
             return jsonify({'error': 'File not found'}), 404
 
+# This is only run for testing.   When we use gunicorn, this ends up not being
+# run.   So be careful of what code is placed here.
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='Run the Storage API backend server')
+    parser = argparse.ArgumentParser(description='Run the Blocks backend server')
     parser.add_argument('-p', '--port', type=int, default=5001,
                         help='Port to run the server on (default: 5001)')
     parser.add_argument('-l', '--log-level', type=str, default='INFO',

--- a/backend/main.py
+++ b/backend/main.py
@@ -42,6 +42,10 @@ app.config['SQLALCHEMY_DATABASE_URI'] = f'sqlite:///{os.path.join(basedir, "proj
 db.init_app(app)
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 
+# Initialize DB tables at startup regardless of how the server is launched (e.g. gunicorn)
+with app.app_context():
+    db.create_all()
+
 # Register API routes
 # Storage API routes (more specific routes first)
 app.add_url_rule('/entries/<path:entry_key>', view_func=StorageEntryResource.as_view('storage_entry'))
@@ -139,9 +143,6 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     logging.getLogger().setLevel(getattr(logging, args.log_level))
-
-    with app.app_context():
-        db.create_all()
 
     logger.info(f"Starting server on port {args.port}...")
     app.run(debug=True, host="0.0.0.0", port=args.port)

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -40,6 +40,7 @@ import * as commonStorage from './storage/common_storage';
 import * as storageModule from './storage/module';
 import * as storageProject from './storage/project';
 import * as clientSideStorage from './storage/client_side_storage';
+import * as serverSideStorage from './storage/server_side_storage';
 
 import * as CustomBlocks from './blocks/setup_custom_blocks';
 
@@ -81,11 +82,15 @@ const LAYOUT_BACKGROUND_COLOR = '#0F0';
 const App: React.FC = (): React.JSX.Element => {
   const [storage, setStorage] = React.useState<commonStorage.Storage | null>(null);
 
-  /** Opens client-side storage asynchronously. */
+  /** Opens storage asynchronously, preferring the backend when available. */
   const openStorage = async (): Promise<void> => {
     try {
-      const clientStorage = await clientSideStorage.openClientSideStorage();
-      setStorage(clientStorage);
+      if (await serverSideStorage.isServerAvailable()) {
+        setStorage(new serverSideStorage.ServerSideStorage());
+      } else {
+        const clientStorage = await clientSideStorage.openClientSideStorage();
+        setStorage(clientStorage);
+      }
     } catch (e) {
       console.error(STORAGE_ERROR_MESSAGE);
       console.error(e);

--- a/frontend/storage/server_side_storage.ts
+++ b/frontend/storage/server_side_storage.ts
@@ -24,6 +24,11 @@ import * as commonStorage from './common_storage';
 
 const API_BASE_URL = '';
 
+function toStorageUrl(path: string): string {
+  const stripped = path.startsWith('/') ? path.slice(1) : path;
+  return `${API_BASE_URL}/storage/${stripped}`;
+}
+
 export async function isServerAvailable(): Promise<boolean> {
   try {
     // Create a timeout promise
@@ -80,65 +85,67 @@ export class ServerSideStorage implements commonStorage.Storage {
   }
 
   async list(path: string): Promise<string[]> {
-    // Ensure path ends with / for directory listing
-    const dirPath = path.endsWith('/') ? path : path + '/';
-    const response = await fetch(`${API_BASE_URL}/storage/${encodeURIComponent(dirPath)}`);
-    
+    if (!path.endsWith('/')) {
+      path += '/';
+    }
+    const response = await fetch(toStorageUrl(path));
+
     if (!response.ok) {
       throw new Error(`Failed to list files: ${response.statusText}`);
     }
-    
+
     const data = await response.json();
     return data.files || [];
   }
 
   async rename(oldPath: string, newPath: string): Promise<void> {
+    const stripped = (p: string) => p.startsWith('/') ? p.slice(1) : p;
     const response = await fetch(`${API_BASE_URL}/storage/rename`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ old_path: oldPath, new_path: newPath }),
+      body: JSON.stringify({ old_path: stripped(oldPath), new_path: stripped(newPath) }),
     });
-    
+
     if (!response.ok) {
       throw new Error(`Failed to rename: ${response.statusText}`);
     }
   }
 
   async fetchFileContentText(filePath: string): Promise<string> {
-    const response = await fetch(`${API_BASE_URL}/storage/${encodeURIComponent(filePath)}`);
-    
+    const response = await fetch(toStorageUrl(filePath));
+
     if (!response.ok) {
       if (response.status === 404) {
         throw new Error(`File not found: ${filePath}`);
       }
       throw new Error(`Failed to fetch file: ${response.statusText}`);
     }
-    
+
     const data = await response.json();
     return data.content || '';
   }
 
   async saveFile(filePath: string, fileContentText: string): Promise<void> {
-    const response = await fetch(`${API_BASE_URL}/storage/${encodeURIComponent(filePath)}`, {
+    const response = await fetch(toStorageUrl(filePath), {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({ content: fileContentText }),
     });
-    
+
     if (!response.ok) {
       throw new Error(`Failed to save file: ${response.statusText}`);
     }
   }
 
   async delete(path: string): Promise<void> {
-    const response = await fetch(`${API_BASE_URL}/storage/${encodeURIComponent(path)}`, {
+    const response = await fetch(toStorageUrl(path), {
       method: 'DELETE',
     });
-    
+
     if (!response.ok) {
       throw new Error(`Failed to delete: ${response.statusText}`);
     }

--- a/frontend/storage/server_side_storage.ts
+++ b/frontend/storage/server_side_storage.ts
@@ -99,13 +99,13 @@ export class ServerSideStorage implements commonStorage.Storage {
   }
 
   async rename(oldPath: string, newPath: string): Promise<void> {
-    const stripped = (p: string) => p.startsWith('/') ? p.slice(1) : p;
+    const stripLeadingSlash = (p: string) => p.startsWith('/') ? p.slice(1) : p;
     const response = await fetch(`${API_BASE_URL}/storage/rename`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ old_path: stripped(oldPath), new_path: stripped(newPath) }),
+      body: JSON.stringify({ old_path: stripLeadingSlash(oldPath), new_path: stripLeadingSlash(newPath) }),
     });
 
     if (!response.ok) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "system_core_blocks",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "system_core_blocks",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@ant-design/icons": "^6.2.5",
         "@blockly/theme-dark": "^8.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "system_core_blocks",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "homepage": "/blocks",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
This PR will require a new release.  It modifies the version of blocks to 0.1.1

It turns out there was a bug where we always used the browser storage even if the backend was available.   When that bug was fixed, it exposed a bug where the db wasn't created if the backend was started with gunicorn (as we do on systemcore).   

That bug was fixed.   This has been tested on Systemcore with the package made.

Fixes #455 