### PR TITLE
Update python tool to not generate json for DefaultUserControl and decorators

### DIFF
--- a/frontend/blocks/utils/generated/runtime_python.json
+++ b/frontend/blocks/utils/generated/runtime_python.json
@@ -140,12 +140,6 @@
         {
             "enums": [],
             "functions": [],
-            "moduleName": "blocks_base_classes.decorators",
-            "moduleVariables": []
-        },
-        {
-            "enums": [],
-            "functions": [],
             "moduleName": "blocks_base_classes.mechanism",
             "moduleVariables": []
         }

--- a/python_tools/json_util.py
+++ b/python_tools/json_util.py
@@ -33,11 +33,24 @@ _LIST_MODULE_NAME_PREFIXES_TO_IGNORE = [
 
 _LIST_MODULE_NAMES_INTERNAL = [
   'blocks_base_classes.block_execution',
+  'blocks_base_classes.decorators',
+  'blocks_base_classes.user_controls',
 ]
 
 _LIST_CLASS_NAMES_INTERNAL = [
   'blocks_base_classes.BlockExecution',
+  'blocks_base_classes.DefaultUserControls',
 ]
+
+_DICT_MODULE_FUNCTION_NAMES_INTERNAL = {
+  'blocks_base_classes': [
+    'Auto',
+    'Group',
+    'Name',
+    'Teleop',
+    'Utility',
+  ],
+}
 
 _COMMON_MARKER = '@Common'
 
@@ -193,6 +206,10 @@ class JsonGenerator:
           if hasattr(module, '__all__') and not (key in module.__all__):
             # Ignore the imported function.
             continue
+
+      if (module_name in _DICT_MODULE_FUNCTION_NAMES_INTERNAL
+          and key in _DICT_MODULE_FUNCTION_NAMES_INTERNAL[module_name]):
+        continue
 
       # Look at each function signature. For overloaded functions, there will be more than one.
       (signatures, comments) = python_util.processFunction(value)

--- a/python_tools/json_util.py
+++ b/python_tools/json_util.py
@@ -510,15 +510,20 @@ class JsonGenerator:
 
     if class_name == 'wpilib.ExpansionHubMotor':
       class_data[_KEY_IS_COMPONENT] = True
+      found_constructor = False
       for constructor_data in class_data[_KEY_CONSTRUCTORS]:
         args = constructor_data[_KEY_FUNCTION_ARGS]
         if (len(args) == 2 and
             args[0][_KEY_ARGUMENT_NAME] == 'usbId' and
             args[1][_KEY_ARGUMENT_NAME] == 'channel'):
+          found_constructor = True
           component_args = []
           component_args.append(self._createArgData('expansionHubMotor', 'SYSTEMCORE_USB_PORT__EXPANSION_HUB_MOTOR_PORT'))
           constructor_data[_KEY_COMPONENT_ARGS] = component_args
           constructor_data[_KEY_IS_COMPONENT] = True
+      if not found_constructor:
+        print(f'ERROR: failed to find expected constructor for {class_name}',
+              file=sys.stderr)
       for function_data in class_data[_KEY_INSTANCE_METHODS]:
         function_name = function_data[_KEY_FUNCTION_NAME]
         # TODO: decide which functions are common.
@@ -536,15 +541,20 @@ class JsonGenerator:
 
     if class_name == 'wpilib.ExpansionHubServo':
       class_data[_KEY_IS_COMPONENT] = True
+      found_constructor = False
       for constructor_data in class_data[_KEY_CONSTRUCTORS]:
         args = constructor_data[_KEY_FUNCTION_ARGS]
         if (len(args) == 2 and
             args[0][_KEY_ARGUMENT_NAME] == 'usbId' and
             args[1][_KEY_ARGUMENT_NAME] == 'channel'):
+          found_constructor = True
           component_args = []
           component_args.append(self._createArgData('expansionHubServo', 'SYSTEMCORE_USB_PORT__EXPANSION_HUB_SERVO_PORT'))
           constructor_data[_KEY_COMPONENT_ARGS] = component_args
           constructor_data[_KEY_IS_COMPONENT] = True
+      if not found_constructor:
+        print(f'ERROR: failed to find expected constructor for {class_name}',
+              file=sys.stderr)
       for function_data in class_data[_KEY_INSTANCE_METHODS]:
         function_name = function_data[_KEY_FUNCTION_NAME]
         # TODO: decide which functions are common.
@@ -559,14 +569,19 @@ class JsonGenerator:
 
     if class_name == 'wpilib.AddressableLED':
       class_data[_KEY_IS_COMPONENT] = True
+      found_constructor = False
       for constructor_data in class_data[_KEY_CONSTRUCTORS]:
         args = constructor_data[_KEY_FUNCTION_ARGS]
         if (len(args) == 1 and
             args[0][_KEY_ARGUMENT_NAME] == 'channel'):
+          found_constructor = True
           component_args = []
           component_args.append(self._createArgData('smartIoPort', 'SYSTEMCORE_SMART_IO_PORT'))
           constructor_data[_KEY_COMPONENT_ARGS] = component_args
           constructor_data[_KEY_IS_COMPONENT] = True
+      if not found_constructor:
+        print(f'ERROR: failed to find expected constructor for {class_name}',
+              file=sys.stderr)
       for function_data in class_data[_KEY_INSTANCE_METHODS]:
         function_name = function_data[_KEY_FUNCTION_NAME]
         # TODO: decide which functions are common.
@@ -578,18 +593,23 @@ class JsonGenerator:
 
     if class_name == 'wpilib.AnalogEncoder':
       class_data[_KEY_IS_COMPONENT] = True
+      found_constructor = False
       for constructor_data in class_data[_KEY_CONSTRUCTORS]:
         args = constructor_data[_KEY_FUNCTION_ARGS]
         if (len(args) == 3 and
             args[0][_KEY_ARGUMENT_NAME] == 'channel' and
             args[1][_KEY_ARGUMENT_NAME] == 'fullRange' and
             args[2][_KEY_ARGUMENT_NAME] == 'expectedZero'):
+          found_constructor = True
           component_args = []
           component_args.append(self._createArgData('smartIoPort', 'SYSTEMCORE_SMART_IO_PORT'))
           component_args.append(self._createArgData(args[1][_KEY_ARGUMENT_NAME], self._getClassName(args[1][_KEY_ARGUMENT_TYPE]), '1.0'))
           component_args.append(self._createArgData(args[2][_KEY_ARGUMENT_NAME], self._getClassName(args[2][_KEY_ARGUMENT_TYPE]), '0.0'))
           constructor_data[_KEY_COMPONENT_ARGS] = component_args
           constructor_data[_KEY_IS_COMPONENT] = True
+      if not found_constructor:
+        print(f'ERROR: failed to find expected constructor for {class_name}',
+              file=sys.stderr)
       for function_data in class_data[_KEY_INSTANCE_METHODS]:
         function_name = function_data[_KEY_FUNCTION_NAME]
         # TODO: decide which functions are common.
@@ -600,18 +620,23 @@ class JsonGenerator:
 
     if class_name == 'wpilib.AnalogPotentiometer':
       class_data[_KEY_IS_COMPONENT] = True
+      found_constructor = False
       for constructor_data in class_data[_KEY_CONSTRUCTORS]:
         args = constructor_data[_KEY_FUNCTION_ARGS]
         if (len(args) == 3 and
             args[0][_KEY_ARGUMENT_NAME] == 'channel' and
             args[1][_KEY_ARGUMENT_NAME] == 'fullRange' and
             args[2][_KEY_ARGUMENT_NAME] == 'offset'):
+          found_constructor = True
           component_args = []
           component_args.append(self._createArgData('smartIoPort', 'SYSTEMCORE_SMART_IO_PORT'))
           component_args.append(self._createArgData(args[1][_KEY_ARGUMENT_NAME], self._getClassName(args[1][_KEY_ARGUMENT_TYPE]), args[1][_KEY_ARGUMENT_DEFAULT_VALUE]))
           component_args.append(self._createArgData(args[2][_KEY_ARGUMENT_NAME], self._getClassName(args[2][_KEY_ARGUMENT_TYPE]), args[2][_KEY_ARGUMENT_DEFAULT_VALUE]))
           constructor_data[_KEY_COMPONENT_ARGS] = component_args
           constructor_data[_KEY_IS_COMPONENT] = True
+      if not found_constructor:
+        print(f'ERROR: failed to find expected constructor for {class_name}',
+              file=sys.stderr)
       for function_data in class_data[_KEY_INSTANCE_METHODS]:
         function_name = function_data[_KEY_FUNCTION_NAME]
         # TODO: decide which functions are common.
@@ -621,14 +646,19 @@ class JsonGenerator:
 
     if class_name == 'wpilib.DigitalInput':
       class_data[_KEY_IS_COMPONENT] = True
+      found_constructor = False
       for constructor_data in class_data[_KEY_CONSTRUCTORS]:
         args = constructor_data[_KEY_FUNCTION_ARGS]
         if (len(args) == 1 and
             args[0][_KEY_ARGUMENT_NAME] == 'channel'):
+          found_constructor = True
           component_args = []
           component_args.append(self._createArgData('smartIoPort', 'SYSTEMCORE_SMART_IO_PORT'))
           constructor_data[_KEY_COMPONENT_ARGS] = component_args
           constructor_data[_KEY_IS_COMPONENT] = True
+      if not found_constructor:
+        print(f'ERROR: failed to find expected constructor for {class_name}',
+              file=sys.stderr)
       for function_data in class_data[_KEY_INSTANCE_METHODS]:
         function_name = function_data[_KEY_FUNCTION_NAME]
         # TODO: decide which functions are common.
@@ -638,18 +668,23 @@ class JsonGenerator:
 
     if class_name == 'wpilib.DutyCycleEncoder':
       class_data[_KEY_IS_COMPONENT] = True
+      found_constructor = False
       for constructor_data in class_data[_KEY_CONSTRUCTORS]:
         args = constructor_data[_KEY_FUNCTION_ARGS]
         if (len(args) == 3 and
             args[0][_KEY_ARGUMENT_NAME] == 'channel' and
             args[1][_KEY_ARGUMENT_NAME] == 'fullRange' and
             args[2][_KEY_ARGUMENT_NAME] == 'expectedZero'):
+          found_constructor = True
           component_args = []
           component_args.append(self._createArgData('smartIoPort', 'SYSTEMCORE_SMART_IO_PORT'))
           component_args.append(self._createArgData(args[1][_KEY_ARGUMENT_NAME], self._getClassName(args[1][_KEY_ARGUMENT_TYPE]), '1'))
           component_args.append(self._createArgData(args[2][_KEY_ARGUMENT_NAME], self._getClassName(args[2][_KEY_ARGUMENT_TYPE]), '0'))
           constructor_data[_KEY_COMPONENT_ARGS] = component_args
           constructor_data[_KEY_IS_COMPONENT] = True
+      if not found_constructor:
+        print(f'ERROR: failed to find expected constructor for {class_name}',
+              file=sys.stderr)
       for function_data in class_data[_KEY_INSTANCE_METHODS]:
         function_name = function_data[_KEY_FUNCTION_NAME]
         # TODO: decide which functions are common.
@@ -661,14 +696,19 @@ class JsonGenerator:
 
     if class_name == 'wpilib.OnboardIMU':
       class_data[_KEY_IS_COMPONENT] = True
+      found_constructor = False
       for constructor_data in class_data[_KEY_CONSTRUCTORS]:
         args = constructor_data[_KEY_FUNCTION_ARGS]
         if (len(args) == 1 and
             args[0][_KEY_ARGUMENT_NAME] == 'mountOrientation'):
+          found_constructor = True
           component_args = []
           component_args.append(self._createArgData(args[0][_KEY_ARGUMENT_NAME], self._getClassName(args[0][_KEY_ARGUMENT_TYPE]), args[0][_KEY_ARGUMENT_DEFAULT_VALUE]))
           constructor_data[_KEY_COMPONENT_ARGS] = component_args
           constructor_data[_KEY_IS_COMPONENT] = True
+      if not found_constructor:
+        print(f'ERROR: failed to find expected constructor for {class_name}',
+              file=sys.stderr)
       for function_data in class_data[_KEY_INSTANCE_METHODS]:
         function_name = function_data[_KEY_FUNCTION_NAME]
         # TODO: decide which functions are common.
@@ -688,14 +728,19 @@ class JsonGenerator:
 
     if class_name ==  'wpilib.PWMSparkMax':
       class_data[_KEY_IS_COMPONENT] = True
+      found_constructor = False
       for constructor_data in class_data[_KEY_CONSTRUCTORS]:
         args = constructor_data[_KEY_FUNCTION_ARGS]
         if (len(args) == 1 and
             args[0][_KEY_ARGUMENT_NAME] == 'channel'):
+          found_constructor = True
           component_args = []
           component_args.append(self._createArgData('smartIoPort', 'SYSTEMCORE_SMART_IO_PORT'))
           constructor_data[_KEY_COMPONENT_ARGS] = component_args
           constructor_data[_KEY_IS_COMPONENT] = True
+      if not found_constructor:
+        print(f'ERROR: failed to find expected constructor for {class_name}',
+              file=sys.stderr)
       for function_data in class_data[_KEY_INSTANCE_METHODS]:
         function_name = function_data[_KEY_FUNCTION_NAME]
         # TODO: decide which functions are common.
@@ -711,17 +756,22 @@ class JsonGenerator:
 
     if class_name == 'rev.A301':
       class_data[_KEY_IS_COMPONENT] = True
+      found_constructor = False
       for constructor_data in class_data[_KEY_CONSTRUCTORS]:
         args = constructor_data[_KEY_FUNCTION_ARGS]
         if (len(args) == 2 and
             args[0][_KEY_ARGUMENT_NAME] == 'busId' and
             args[1][_KEY_ARGUMENT_NAME] == 'deviceId'):
+          found_constructor = True
           component_args = []
           # TODO: consider hardcoding a default value for busId.
           component_args.append(self._createArgData(args[0][_KEY_ARGUMENT_NAME], self._getClassName(args[0][_KEY_ARGUMENT_TYPE]), args[0][_KEY_ARGUMENT_DEFAULT_VALUE]))
           component_args.append(self._createArgData(args[1][_KEY_ARGUMENT_NAME], self._getClassName(args[1][_KEY_ARGUMENT_TYPE]), args[1][_KEY_ARGUMENT_DEFAULT_VALUE]))
           constructor_data[_KEY_COMPONENT_ARGS] = component_args
           constructor_data[_KEY_IS_COMPONENT] = True
+      if not found_constructor:
+        print(f'ERROR: failed to find expected constructor for {class_name}',
+              file=sys.stderr)
       for function_data in class_data[_KEY_INSTANCE_METHODS]:
         function_name = function_data[_KEY_FUNCTION_NAME]
         # TODO: decide which functions are common.

--- a/runtime_python/blocks_base_classes/__init__.py
+++ b/runtime_python/blocks_base_classes/__init__.py
@@ -1,6 +1,6 @@
 """Base classes for SystemCore blocks interface."""
 
-from .decorators import Teleop, Auto, Test, Name, Group
+from .decorators import Teleop, Auto, Utility, Name, Group
 from .mechanism import Mechanism
 from .block_execution import BlockExecution
 from .user_controls import DefaultUserControls
@@ -8,7 +8,7 @@ from .user_controls import DefaultUserControls
 __all__ = [
     'Teleop',
     'Auto',
-    'Test',
+    'Utility',
     'Name',
     'Group',
     'Mechanism',

--- a/runtime_python/blocks_base_classes/__init__.py
+++ b/runtime_python/blocks_base_classes/__init__.py
@@ -13,4 +13,5 @@ __all__ = [
     'Group',
     'Mechanism',
     'BlockExecution',
+    'DefaultUserControls',
 ]

--- a/runtime_python/blocks_base_classes/block_execution.py
+++ b/runtime_python/blocks_base_classes/block_execution.py
@@ -1,6 +1,7 @@
 # This class provides functions used when executing blocks.
 
 import json
+from typing import Any
 
 class BlockExecution:
     current_class_name: str = ''
@@ -20,12 +21,12 @@ class BlockExecution:
         return True
 
     @classmethod
-    def endBlockExecution(cls, value):
+    def endBlockExecution(cls, value: Any):
         cls.current_block_execution_finished = True
         return value
 
     @classmethod
-    def handleFatalError(cls, e) -> None:
+    def handleFatalError(cls, e: Exception) -> None:
         if cls.current_block_label:
             subordinating_conjunction = (
                 'after' if cls.current_block_execution_finished else 'while')

--- a/runtime_python/blocks_base_classes/decorators.py
+++ b/runtime_python/blocks_base_classes/decorators.py
@@ -6,7 +6,7 @@ def Teleop(cls):
 def Auto(cls):
     return cls
 
-def Test(cls):
+def Utility(cls):
     return cls
 
 def Name(cls, str):

--- a/runtime_python/blocks_base_classes/user_controls.py
+++ b/runtime_python/blocks_base_classes/user_controls.py
@@ -7,5 +7,5 @@ JOYSTICK_PORTS = 6
 class DefaultUserControls:
     def __init__(self):
         self.m_gamepads = [wpilib.Gamepad(i) for i in range(JOYSTICK_PORTS)]
-    def getGamepad(self, port):
+    def getGamepad(self, port: int) -> wpilib.Gamepad:
         return self.m_gamepads[port]


### PR DESCRIPTION
## Overview
Update python tool:
- Ignore DefaultUserControl and decorators when generating json
- Print an error if a python3.12 generate_json.py --output_directory=../frontend/blocks/utils

Fixed some style issues in runtime_python code
- Added python type hints where to DefaultUserControl and BlockExecution functions
- Changed Test to Utility

## Linked Issues
N/A

## Type of Change
<!-- Please check the option that applies to this PR: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [x] Code style/formatting updates

## How Has This Been Tested?
1. Ran `python3.12 generate_json.py --output_directory=../frontend/blocks/utils`
2. Confirmed there are no errors printed.
3. Checked the generated json output and verified it was what I expected

## Checklist
<!-- Review the options below and check off what has been completed. -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [N/A] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [N/A] I have run through the [docs/testing_before_pr_checklist.md]
