### PR TITLE
Lengthen timeout

### DIFF
--- a/backend/start.sh
+++ b/backend/start.sh
@@ -3,4 +3,4 @@
 source ../venv/bin/activate
 
 # Note - this MUST match the port given in packaging/control/control
-gunicorn -b 0.0.0.0:9001 main:app
+gunicorn --timeout 60 -b 0.0.0.0:9001 main:app


### PR DESCRIPTION
## Overview
@bhjelstrom was having trouble with deploys timing out that took more than 30 seconds.  This extends the gunicorn timeout to 60 seconds which matches the UI timeout.

## Linked Issues
None

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Code style/formatting updates

## How Has This Been Tested?
Made a package, installed it, verified that it started and that the change was in start.sh in /opt/blocks/backend/

## Checklist
<!-- Review the options below and check off what has been completed. -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- N/A I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [N/A] I have run through the [docs/testing_before_pr_checklist.md]
