### PR TITLE
Put _ instead of " " when the spacebar is pressed for project and components

### DIFF
--- a/frontend/reactComponents/ClassNameComponent.tsx
+++ b/frontend/reactComponents/ClassNameComponent.tsx
@@ -104,7 +104,7 @@ export default function ClassNameComponent(props: ClassNameComponentProps): Reac
 
   /** Handles input change with automatic capitalization. */
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
-    const value = e.target.value;
+    const value = e.target.value.replace(/ /g, '_');
     // Force first character to be uppercase
     const capitalizedValue = value.charAt(0).toUpperCase() + value.slice(1);
     props.setNewItemName(capitalizedValue);

--- a/frontend/reactComponents/ProjectManageModal.tsx
+++ b/frontend/reactComponents/ProjectManageModal.tsx
@@ -350,7 +350,7 @@ export default function ProjectManageModal(props: ProjectManageModalProps): Reac
                   <p>{t('PROJECT_NAME_EXISTS', { projectName: preferredName })}</p>
                   <Antd.Input
                     defaultValue={uploadProjectName}
-                    onChange={(e) => { inputValue = e.target.value; }}
+                    onChange={(e) => { inputValue = e.target.value.replace(/ /g, '_'); }}
                   />
                 </div>
               ),

--- a/frontend/reactComponents/ProjectNameComponent.tsx
+++ b/frontend/reactComponents/ProjectNameComponent.tsx
@@ -90,7 +90,7 @@ export default function ProjectNameComponent(props: ProjectNameComponentProps): 
 
   /** Handles input change with automatic capitalization. */
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
-    const value = e.target.value;
+    const value = e.target.value.replace(/ /g, '_');
     // Force first character to be uppercase
     const capitalizedValue = value.charAt(0).toUpperCase() + value.slice(1);
     props.setNewItemName(capitalizedValue);


### PR DESCRIPTION
## Overview
A " " is not allowed in project and component names.   This is a help to the user in that when they press the spacebar, they get an "_" instead of " " which will make a name that isn't valid.

## Linked Issues
Fixes #443

## Type of Change
<!-- Please check the option that applies to this PR: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Code style/formatting updates

## How Has This Been Tested?
Ran the project and typed in " " for the three places modified, project names, component names, and the merge dialog.

## Checklist
<!-- Review the options below and check off what has been completed. -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [N/A] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run through the [docs/testing_before_pr_checklist.md]
