### PR TITLE
Instead of assuming a number at the end is a counter, only assume that a counter is _ followed by a number.

### DIFF
--- a/frontend/blocks/utils/validator.ts
+++ b/frontend/blocks/utils/validator.ts
@@ -61,11 +61,11 @@ export function makeLegalName(proposedName: string, otherNames: string[], mustBe
 
   while (otherNamesLowerCase.includes(name.toLowerCase())) {
     // Collision with another name.
-    const r = name.match(/^(.*?)(\d+)$/);
+    const r = name.match(/^(.*?)_(\d+)$/);
     if (!r) {
-      name += '2';
+      name += '_1';
     } else {
-      name = r[1] + (parseInt(r[2]) + 1);
+      name = r[1] + '_' + (parseInt(r[2]) + 1);
     }
   }
   return name;


### PR DESCRIPTION
## Overview
We used to assume that xxxnnn that the n was a counter so we incremented it.  However this doesn't work for A301, which was made to be A302.   So this assumes that the counter is _nnn.   So when myA301 duplicates, the new name will be myA301_1 instead of of myA302.

## Linked Issues
Fixes #444

## Type of Change
<!-- Please check the option that applies to this PR: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Code style/formatting updates

## How Has This Been Tested?
I went through and created multiple components and mechanisms.  Some of which ended in a number and some of which that didn't.

I didn't run through the PR checklist because it doesn't involve any duplicates.

## Checklist
<!-- Review the options below and check off what has been completed. -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [N/A] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [N/A] I have run through the [docs/testing_before_pr_checklist.md]
