### PR TITLE
Add blocks to fill in function argument sockets

### DIFF
--- a/frontend/blocks/mrc_call_python_function.ts
+++ b/frontend/blocks/mrc_call_python_function.ts
@@ -1363,7 +1363,7 @@ function processArgs(
       name: argName,
       type: args[i].type,
     });
-    // Check if we should plug a variable getter block into the argument input socket.
+    // Plug a block (or shadow block) into the argument input socket, if appropriate.
     const input = value.valueForFunctionArgInput(args[i].type, args[i].defaultValue);
     if (input) {
       inputs['ARG' + i] = input;

--- a/frontend/blocks/utils/value.ts
+++ b/frontend/blocks/utils/value.ts
@@ -32,43 +32,56 @@ export function valueForFunctionArgInput(argType: string, argDefaultValue: strin
   if (valueVarName) {
     return variable.createVariableGetterBlockValue(valueVarName);
   }
-  if (!argDefaultValue) {
-    return null;
-  }
   const alias = getAlias(argType);
   if (alias) {
     argType = alias;
   }
   switch (argType) {
     case 'int':
-      const intNum = parseInt(argDefaultValue, 10);
-      if (!isNaN(intNum) && intNum.toString() === argDefaultValue) {
-        return createNumberShadowValue(intNum);
+      if (argDefaultValue) {
+        const intNum = parseInt(argDefaultValue, 10);
+        if (!isNaN(intNum) && intNum.toString() === argDefaultValue) {
+          return createNumberShadowValue(intNum);
+        }
+      } else {
+        return createNumberBlock(0);
       }
       break;
     case 'float':
-      const floatNum = Number(argDefaultValue);
-      if (!isNaN(floatNum)) {
-        return createNumberShadowValue(floatNum)
+      if (argDefaultValue) {
+        const floatNum = Number(argDefaultValue);
+        if (!isNaN(floatNum)) {
+          return createNumberShadowValue(floatNum)
+        }
+      } else {
+        return createNumberBlock(0);
       }
       break;
     case 'str':
-      if (argDefaultValue === 'None') {
-        return createNoneShadowValue();
-      }
-      // If argDefaultValue is surrounded by single or double quotes, it's a literal string.
-      if (argDefaultValue.startsWith("'") && argDefaultValue.endsWith("'") ||
-          argDefaultValue.startsWith('"') && argDefaultValue.endsWith('"')) {
-        const textValue = argDefaultValue.substring(1, argDefaultValue.length-1);
-        return createTextShadowValue(textValue);
+      if (argDefaultValue) {
+        if (argDefaultValue === 'None') {
+          return createNoneShadowValue();
+        }
+        // If argDefaultValue is surrounded by single or double quotes, it's a literal string.
+        if (argDefaultValue.startsWith("'") && argDefaultValue.endsWith("'") ||
+            argDefaultValue.startsWith('"') && argDefaultValue.endsWith('"')) {
+          const textValue = argDefaultValue.substring(1, argDefaultValue.length-1);
+          return createTextShadowValue(textValue);
+        }
+      } else {
+        return createTextBlock('');
       }
       break;
     case 'bool':
-      if (argDefaultValue === 'True') {
-        return createBooleanShadowValue(true);
-      }
-      if (argDefaultValue === 'False') {
-        return createBooleanShadowValue(false);
+      if (argDefaultValue) {
+        if (argDefaultValue === 'True') {
+          return createBooleanShadowValue(true);
+        }
+        if (argDefaultValue === 'False') {
+          return createBooleanShadowValue(false);
+        }
+      } else {
+        return createBooleanBlock(false);
       }
       break;
   }


### PR DESCRIPTION
## Overview
Add blocks to fill in function argument sockets (even if there is no default value) when the argument type is int, float, str or bool.

## Linked Issues
Fixes #417

## Type of Change
<!-- Please check the option that applies to this PR: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Code style/formatting updates

## How Has This Been Tested?
I looked at the following blocks:
1. wpiutil.getStackTrace, which takes an `int`.
2. wpimath.angleModulus, which takes a wpimath.units.radians, which is an alias for `float`.
3. wpilib.reportError, which takes a `str` and a `bool`.


## Checklist
<!-- Review the options below and check off what has been completed. -->
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have run through the [docs/testing_before_pr_checklist.md]
