### PR TITLE
Add when block

### DIFF
--- a/frontend/blocks/mrc_when.ts
+++ b/frontend/blocks/mrc_when.ts
@@ -1,0 +1,84 @@
+/**
+ * @license
+ * Copyright 2026 Porpoiseful LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Block that defines a condition that is checked every periodic tick.
+ * @author alan@porpoiseful.com (Alan Smith)
+ */
+import * as Blockly from 'blockly';
+import { Order } from 'blockly/python';
+
+import { MRC_STYLE_WHEN } from '../themes/styles';
+import { ExtendedPythonGenerator } from '../editor/extended_python_generator';
+import { createBooleanShadowValue } from './utils/value';
+import * as toolboxItems from '../toolbox/items';
+
+export const BLOCK_NAME = 'mrc_when';
+
+const WHEN_METHOD_PREFIX = 'when_';
+
+export const INPUT_BOOL = 'BOOL';
+const INPUT_DO = 'DO';
+
+const WHEN_BLOCK = {
+  /**
+   * Block initialization.
+   */
+  init: function (this: Blockly.Block): void {
+    this.appendValueInput(INPUT_BOOL)
+        .setCheck('Boolean')
+        .appendField(Blockly.Msg.WHEN);
+    this.appendStatementInput(INPUT_DO);
+    this.setInputsInline(false);
+    this.setStyle(MRC_STYLE_WHEN);
+    this.setPreviousStatement(false);
+    this.setNextStatement(false);
+  },
+};
+
+export const setup = function () {
+  Blockly.Blocks[BLOCK_NAME] = WHEN_BLOCK;
+};
+
+export const pythonFromBlock = function (
+  block: Blockly.Block,
+  generator: ExtendedPythonGenerator,
+) {
+  // Name the method after the position of this block among all mrc_when blocks in the
+  // workspace, in top-to-bottom order.
+  const whenBlocks = block.workspace.getBlocksByType(BLOCK_NAME, true);
+  const index = whenBlocks.indexOf(block) + 1;
+  const methodName = WHEN_METHOD_PREFIX + index;
+
+  const condition = generator.valueToCode(block, INPUT_BOOL, Order.NONE) || 'False';
+  const branch = generator.statementToCode(block, INPUT_DO) || generator.PASS;
+
+  let code = `def ${methodName}(self):\n`;
+  code += generator.INDENT + `if ${condition}:\n`;
+  code += generator.prefixLines(branch, generator.INDENT);
+
+  generator.addClassMethodDefinition(methodName, code);
+  generator.addWhenMethodName(methodName);
+
+  return '';
+};
+
+export function createWhenBlock(): toolboxItems.Block {
+  const inputs: {[key: string]: any} = {};
+  inputs[INPUT_BOOL] = createBooleanShadowValue(true);
+  return new toolboxItems.Block(BLOCK_NAME, null, null, inputs);
+}

--- a/frontend/blocks/setup_custom_blocks.ts
+++ b/frontend/blocks/setup_custom_blocks.ts
@@ -19,6 +19,7 @@ import * as ParamContainer from './mrc_param_container'
 import * as Port from './mrc_port';
 import * as SetPythonVariable from './mrc_set_python_variable';
 import * as Steps from './mrc_steps';
+import * as When from './mrc_when';
 import * as StepContainer from './mrc_step_container';
 import * as JumpToStep from './mrc_jump_to_step';
 import * as GamepadBoolean from './mrc_gamepad_boolean';
@@ -47,6 +48,7 @@ const customBlocks = [
   Port,
   SetPythonVariable,
   Steps,
+  When,
   StepContainer,
   JumpToStep,
   GamepadBoolean,

--- a/frontend/editor/extended_python_generator.ts
+++ b/frontend/editor/extended_python_generator.ts
@@ -139,6 +139,7 @@ export class ExtendedPythonGenerator extends PythonGenerator {
 
   private classMethods: {[key: string]: string} = Object.create(null);
   private registerEventHandlerStatements: string[] = [];
+  private whenMethodNames: string[] = [];
 
   private importedNames: {[name: string]: string} = Object.create(null); // value is an import statement
   private fromModuleImportNames: {[module: string]: string[]} = Object.create(null); // value is an array of names being imported from the module.
@@ -299,6 +300,7 @@ export class ExtendedPythonGenerator extends PythonGenerator {
     this.hasAnyEventHandlers = false;
     this.classMethods = Object.create(null);
     this.registerEventHandlerStatements = [];
+    this.whenMethodNames = [];
     this.importedNames = Object.create(null);
     this.fromModuleImportNames = Object.create(null);
     this.opModeDetails = null;
@@ -389,6 +391,10 @@ export class ExtendedPythonGenerator extends PythonGenerator {
     this.registerEventHandlerStatements.push(registerEventHandlerStatement);
   }
 
+  addWhenMethodName(whenMethodName: string): void {
+    this.whenMethodNames.push(whenMethodName);
+  }
+
   getMechanismInitArgNames(): string[] {
     return this.mechanismInitArgNames;
   }
@@ -436,6 +442,9 @@ export class ExtendedPythonGenerator extends PythonGenerator {
         );
         this.classMethods['opmodePeriodic'] = (
             'def opmodePeriodic(self) -> None:\n' +
+            // Generate code to call each when_ method. This goes at the top, so that the when
+            // conditions are checked before anything else happens on this tick.
+            this.getWhenCalls() +
             this.INDENT + 'for mechanism in self.mechanisms:\n' +
             this.INDENT.repeat(2) + 'mechanism.opmodePeriodic()\n'
         );
@@ -446,12 +455,24 @@ export class ExtendedPythonGenerator extends PythonGenerator {
         );
       }
 
+      if (this.getModuleType() === storageModule.ModuleType.MECHANISM) {
+        // Generate code to call each when_ method, at the top of opmodePeriodic, so that the
+        // when conditions are checked before anything else happens on this tick.
+        const whenCalls = this.getWhenCalls();
+        if (whenCalls) {
+          this.classMethods['opmodePeriodic'] =
+              this.insertCodeIntoMethod('opmodePeriodic', whenCalls);
+        }
+      }
+
       if (this.getModuleType() === storageModule.ModuleType.OPMODE) {
         // Add code to the Start method to call robot.opmodeStart.
-        this.classMethods[START_METHOD_NAME] = this.insertCodeToCallRobot(START_METHOD_NAME, 'opmodeStart');
+        this.classMethods[START_METHOD_NAME] = this.insertCodeIntoMethod(START_METHOD_NAME, '', 'opmodeStart');
 
-        // Add code to the periodic method to call robot.opmodePeriodic.
-        let periodicCode = this.insertCodeToCallRobot(PERIODIC_METHOD_NAME, 'opmodePeriodic');
+        // Add code to the periodic method to call robot.opmodePeriodic. The when_ method calls
+        // go at the top, before that, so that the when conditions are checked before anything
+        // else happens on this tick.
+        let periodicCode = this.insertCodeIntoMethod(PERIODIC_METHOD_NAME, this.getWhenCalls(), 'opmodePeriodic');
         if (STEPS_METHOD_NAME in this.classMethods) {
           // Generate code to call the steps method after the user's code.
           periodicCode += this.INDENT + `self.${STEPS_METHOD_NAME}()\n`;
@@ -459,7 +480,7 @@ export class ExtendedPythonGenerator extends PythonGenerator {
         this.classMethods[PERIODIC_METHOD_NAME] = periodicCode;
 
         // Add code to the End method to call robot.opmodeEnd.
-        this.classMethods[END_METHOD_NAME] = this.insertCodeToCallRobot(END_METHOD_NAME, 'opmodeEnd');
+        this.classMethods[END_METHOD_NAME] = this.insertCodeIntoMethod(END_METHOD_NAME, '', 'opmodeEnd');
       }
 
       const classMethods = [];
@@ -514,7 +535,25 @@ export class ExtendedPythonGenerator extends PythonGenerator {
     return super.finish(code);
   }
 
-  private insertCodeToCallRobot(methodName: string, robotMethodName: string): string {
+  /**
+   * Returns code to call each registered when_ method, one call per line, each indented one
+   * level. Returns '' if there are no when_ methods.
+   */
+  private getWhenCalls(): string {
+    let whenCalls = '';
+    for (const whenMethodName of this.whenMethodNames) {
+      whenCalls += this.INDENT + `self.${whenMethodName}()\n`;
+    }
+    return whenCalls;
+  }
+
+  /**
+   * Builds (or rebuilds) the given method's code, inserting prefixCode immediately after the
+   * def line and the call to super().<methodName>() (if any is needed), and, if robotMethodName
+   * is given, a call to self.robot.<robotMethodName>() immediately after prefixCode. Any code
+   * already registered for this method (e.g., from the user's blocks) is preserved after that.
+   */
+  private insertCodeIntoMethod(methodName: string, prefixCode: string, robotMethodName?: string): string {
     let defAndSuper = `def ${methodName}(self):\n`;
     if (this.shouldGenerateSuperCall(methodName)) {
       defAndSuper += this.INDENT + `super().${methodName}()\n`;
@@ -531,8 +570,8 @@ export class ExtendedPythonGenerator extends PythonGenerator {
       // The user has not defined the method. We will define it now.
       code = '';
     }
-    // Generate code to call the robot method immediately after calling the superclass method.
-    return defAndSuper + this.INDENT + `self.robot.${robotMethodName}()\n` + code;
+    const robotCall = robotMethodName ? this.INDENT + `self.robot.${robotMethodName}()\n` : '';
+    return defAndSuper + prefixCode + robotCall + code;
   }
 
   setOpModeDetails(opModeDetails: OpModeDetails) {

--- a/frontend/themes/styles.ts
+++ b/frontend/themes/styles.ts
@@ -35,6 +35,7 @@ export const MRC_STYLE_COMPONENTS = 'mrc_style_components';
 export const MRC_STYLE_EVENTS = 'mrc_style_events';
 export const MRC_STYLE_PORTS = 'mrc_style_ports';
 export const MRC_STYLE_EVENT_HANDLER = 'mrc_style_event_handler';
+export const MRC_STYLE_WHEN = 'mrc_style_when';
 export const MRC_STYLE_DRIVER_STATION = 'mrc_style_driver_station';
 export const MRC_CATEGORY_STYLE_COMPONENTS = 'mrc_category_style_components';
 
@@ -58,6 +59,10 @@ export const add_mrc_styles = function (theme: Blockly.Theme): Blockly.Theme {
     });
     theme.setBlockStyle(MRC_STYLE_STEPS, {
         ...procedureStyle,
+    });
+    theme.setBlockStyle(MRC_STYLE_WHEN, {
+        ...procedureStyle,
+        hat: "cap"
     });
     theme.setBlockStyle(MRC_STYLE_ENUM, {
         ...variableStyle

--- a/frontend/toolbox/driver_station_category.ts
+++ b/frontend/toolbox/driver_station_category.ts
@@ -6,6 +6,8 @@ import { BLOCK_NAME as MRC_CALL_PYTHON_FUNCTION } from '../blocks/mrc_call_pytho
 import { BLOCK_NAME as MRC_GAMEPAD_BOOLEAN  } from '../blocks/mrc_gamepad_boolean';
 import { BLOCK_NAME as MRC_GAMEPAD_ANALOG  } from '../blocks/mrc_gamepad_analog';
 import { BLOCK_NAME as MRC_GAMEPAD_RUMBLE  } from '../blocks/mrc_gamepad_rumble';
+import { BLOCK_NAME as MRC_WHEN, INPUT_BOOL as MRC_WHEN_INPUT_BOOL } from '../blocks/mrc_when';
+import * as Gamepad from '../fields/field_gamepads';
 
 // import { BLOCK_NAME as MRC_GAMEPAD_BOOLEAN_EVENT  } from '../blocks/mrc_gamepad_boolean_event';
 
@@ -59,9 +61,27 @@ function getDriverStationGamepadsCategory(_editor: Editor): toolboxItems.Categor
                 new toolboxItems.Block(MRC_GAMEPAD_BOOLEAN, null, null, null),
                 new toolboxItems.Block(MRC_GAMEPAD_ANALOG, null, null, null),
                 new toolboxItems.Block(MRC_GAMEPAD_RUMBLE, null, null, null),
+                createSampleWhenGamepadButtonBlock(),
                 // TODO: Add events back here when we figure out how the code will be generated
                 //new toolboxItems.Label("Events"),
                 //new toolboxItems.Block(MRC_GAMEPAD_BOOLEAN_EVENT, null, null, null),
               ],
               toolboxItems.ExpandedState.EXPANDED);
+}
+
+// Creates a sample "when" block, with a shadow block for "Gamepad 0 A is down" plugged
+// into its condition, to show how the when block can be used with a gamepad button.
+function createSampleWhenGamepadButtonBlock(): toolboxItems.Block {
+    const inputs: {[key: string]: any} = {};
+    inputs[MRC_WHEN_INPUT_BOOL] = {
+        shadow: {
+            type: MRC_GAMEPAD_BOOLEAN,
+            fields: {
+                [Gamepad.PORT_FIELD_NAME]: '0',
+                [Gamepad.BUTTON_FIELD_NAME]: 'SOUTH_FACE',
+                [Gamepad.ACTION_FIELD_NAME]: 'IS_DOWN',
+            },
+        },
+    };
+    return new toolboxItems.Block(MRC_WHEN, null, null, inputs);
 }

--- a/frontend/toolbox/methods_category.ts
+++ b/frontend/toolbox/methods_category.ts
@@ -37,6 +37,7 @@ import {
     createCustomMethodBlockWithReturn,
     getBaseClassBlocks } from '../blocks/mrc_class_method_def';
 import { createStepsBlock } from '../blocks/mrc_steps';
+import { createWhenBlock } from '../blocks/mrc_when';
 import { Editor } from '../editor/editor';
 
 
@@ -73,6 +74,10 @@ class MethodsCategory {
 
     // Collect the method names that are already overridden in the blockly workspace.
     const methodNamesAlreadyOverridden = editor.getMethodNamesAlreadyOverriddenInWorkspace();
+
+    // The when block is allowed in the Robot, Mechanism, and OpMode modules. In a Robot or
+    // Mechanism, its when_ methods are called from opmodePeriodic; in an OpMode, from periodic.
+    contents.push(createWhenBlock());
 
     switch (editor.getModuleType()) {
       case storageModule.ModuleType.ROBOT:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "system_core_blocks",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "system_core_blocks",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "dependencies": {
         "@ant-design/icons": "^6.3.2",
         "@blockly/theme-dark": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "system_core_blocks",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "homepage": "/blocks",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
## Overview
This adds a trivial implementation of events by letting the student create anything that will be executed on each "tick" if the boolean expression evaluates to True.

## Linked Issues
The idea for this came from feedback from [@j5515]( https://github.com/j5515) and [@GrahamSH-LLK](https://github.com/GrahamSH-LLK).   

## Type of Change
<!-- Please check the option that applies to this PR: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Code style/formatting updates

## How Has This Been Tested?
* Put multiple ones into opmodes
* Put multiple ones into robot
* Put multiple ones into mechanisms

## Checklist
<!-- Review the options below and check off what has been completed. -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [N/A] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [N/A] I have run through the [docs/testing_before_pr_checklist.md]
