### PR TITLE
Allow user to select renderer - default is Zelos (Scratch like)

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -146,7 +146,7 @@ interface AppContentProps {
 
 const AppContent: React.FC<AppContentProps> = ({ project, setProject }): React.JSX.Element => {
   const { t, i18n } = useTranslation();
-  const { settings, updateLanguage, updateTheme, updateShowSimpleClassNames, updateOpenTabs, getOpenTabs, storage, isLoading } = useUserSettings();
+  const { settings, updateLanguage, updateTheme, updateShowSimpleClassNames, updateRenderer, updateOpenTabs, getOpenTabs, storage, isLoading } = useUserSettings();
 
   const [alertErrorMessage, setAlertErrorMessage] = React.useState('');
   const [messageApi, contextHolder] = Antd.message.useMessage();
@@ -162,6 +162,8 @@ const AppContent: React.FC<AppContentProps> = ({ project, setProject }): React.J
   const [themeInitialized, setThemeInitialized] = React.useState(false);
   const [showSimpleClassNames, setShowSimpleClassNames] = React.useState(true);
   const [showSimpleClassNamesInitialized, setShowSimpleClassNamesInitialized] = React.useState(false);
+  const [renderer, setRenderer] = React.useState('zelos');
+  const [rendererInitialized, setRendererInitialized] = React.useState(false);
   const [tourOpen, setTourOpen] = React.useState(false);
 
   const hasCheckedTour = React.useRef(false);
@@ -192,6 +194,19 @@ const AppContent: React.FC<AppContentProps> = ({ project, setProject }): React.J
       }
     }
   }, [settings.theme, theme, themeInitialized, isLoading]);
+
+  /** Initialize renderer from UserSettings when app first starts. */
+  React.useEffect(() => {
+    // Only proceed if settings are loaded
+    if (!isLoading) {
+      if (!rendererInitialized && settings.renderer && settings.renderer !== renderer) {
+        setRenderer(settings.renderer);
+        setRendererInitialized(true);
+      } else if (!rendererInitialized) {
+        setRendererInitialized(true);
+      }
+    }
+  }, [settings.renderer, renderer, rendererInitialized, isLoading]);
 
   /** Initialize showSimpleClassNames from UserSettings when app first starts. */
   React.useEffect(() => {
@@ -241,6 +256,22 @@ const AppContent: React.FC<AppContentProps> = ({ project, setProject }): React.J
 
     saveThemeChange();
   }, [theme, settings.theme, updateTheme, themeInitialized, isLoading]);
+
+  /** Save renderer changes to UserSettings when renderer changes. */
+  React.useEffect(() => {
+    const saveRendererChange = async () => {
+      // Only save if this is not the initial load and renderer is different from settings
+      if (rendererInitialized && renderer !== settings.renderer && !isLoading) {
+        try {
+          await updateRenderer(renderer);
+        } catch (error) {
+          console.error('Failed to save renderer setting:', error);
+        }
+      }
+    };
+
+    saveRendererChange();
+  }, [renderer, settings.renderer, updateRenderer, rendererInitialized, isLoading]);
 
   /** Save showSimpleClassNames changes to UserSettings when showSimpleClassNames changes. */
   React.useEffect(() => {
@@ -599,6 +630,8 @@ const AppContent: React.FC<AppContentProps> = ({ project, setProject }): React.J
                 openWPIToolboxSettings={() => setToolboxSettingsModalIsOpen(true)}
                 theme={theme}
                 setTheme={setTheme}
+                renderer={renderer}
+                setRenderer={setRenderer}
                 showSimpleClassNames={showSimpleClassNames}
                 setShowSimpleClassNames={setShowSimpleClassNames}
                 saveCurrentTab={saveCurrentTab}
@@ -621,6 +654,7 @@ const AppContent: React.FC<AppContentProps> = ({ project, setProject }): React.J
                 onProjectChanged={onProjectChanged}
                 storage={storage}
                 theme={theme}
+                renderer={renderer}
                 showSimpleClassNames={showSimpleClassNames}
                 shownPythonToolboxCategories={shownPythonToolboxCategories}
                 messageApi={messageApi}

--- a/frontend/i18n/locales/en.json
+++ b/frontend/i18n/locales/en.json
@@ -70,6 +70,7 @@
     "WPI_TOOLBOX": "WPI Toolbox",
     "SHOW_SIMPLE_CLASS_NAMES": "Shorten Class Names on Blocks",
     "THEME": "Theme",
+    "STYLE": "Block Style",
     "LANGUAGE": "Language",
     "SELECT_LANGUAGE": "Select Language",
     "ENGLISH": "English",
@@ -163,6 +164,17 @@
         "PRIMARY_BUTTON": "Primary",
         "PREVIEW": "Theme Preview",
         "PREVIEW_DESCRIPTION": "The selected theme will be applied to the entire application interface."
+    },
+    "RENDERER_MODAL": {
+        "ZELOS": "Zelos (Scratch-like)",
+        "ZELOS_DESCRIPTION": "Rounded, colorful blocks with icon-based inputs, similar to Scratch.",
+        "GERAS": "Geras (Classic)",
+        "GERAS_DESCRIPTION": "The original Blockly look, with square blocks and inline inputs.",
+        "THRASOS": "Thrasos",
+        "THRASOS_DESCRIPTION": "A modern take on the classic Blockly look.",
+        "SELECTION": "Block Style Selection",
+        "APPLY": "Apply Style",
+        "CHOOSE_DESCRIPTION": "Choose how blocks are drawn in the workspace. The preview below updates as you choose."
     },
     "TOUR": {
         "MENU_ITEM": "Tour",

--- a/frontend/i18n/locales/es.json
+++ b/frontend/i18n/locales/es.json
@@ -65,6 +65,7 @@
     "WPI_TOOLBOX": "Caja de Herramientas WPI",
     "SHOW_SIMPLE_CLASS_NAMES": "Acortar los nombres de clase en los bloques",
     "THEME": "Tema",
+    "STYLE": "Estilo de Bloques",
     "LANGUAGE": "Idioma",
     "SELECT_LANGUAGE": "Seleccionar idioma",
     "ENGLISH": "Inglés",
@@ -164,6 +165,17 @@
         "PRIMARY_BUTTON": "Primario",
         "PREVIEW": "Vista Previa del Tema",
         "PREVIEW_DESCRIPTION": "El tema seleccionado se aplicará a toda la interfaz de la aplicación."
+    },
+    "RENDERER_MODAL": {
+        "ZELOS": "Zelos (estilo Scratch)",
+        "ZELOS_DESCRIPTION": "Bloques redondeados y coloridos con entradas basadas en iconos, similar a Scratch.",
+        "GERAS": "Geras (Clásico)",
+        "GERAS_DESCRIPTION": "El aspecto original de Blockly, con bloques cuadrados y entradas en línea.",
+        "THRASOS": "Thrasos",
+        "THRASOS_DESCRIPTION": "Una versión moderna del aspecto clásico de Blockly.",
+        "SELECTION": "Selección de Estilo de Bloques",
+        "APPLY": "Aplicar Estilo",
+        "CHOOSE_DESCRIPTION": "Elija cómo se dibujan los bloques en el área de trabajo. La vista previa se actualiza a medida que elige."
     },
     "TOUR": {
         "MENU_ITEM": "Tour",

--- a/frontend/i18n/locales/fr.json
+++ b/frontend/i18n/locales/fr.json
@@ -71,6 +71,7 @@
     "WPI_TOOLBOX": "Boîte à outils WPI",
     "SHOW_SIMPLE_CLASS_NAMES": "Abréger les noms de classe sur les blocs",
     "THEME": "Thème",
+    "STYLE": "Style des Blocs",
     "LANGUAGE": "Langue",
     "SELECT_LANGUAGE": "Sélectionner la langue",
     "ENGLISH": "Anglais",
@@ -164,6 +165,17 @@
         "PRIMARY_BUTTON": "Principal",
         "PREVIEW": "Aperçu du thème",
         "PREVIEW_DESCRIPTION": "Le thème sélectionné sera appliqué à toute l'interface de l'application."
+    },
+    "RENDERER_MODAL": {
+        "ZELOS": "Zelos (style Scratch)",
+        "ZELOS_DESCRIPTION": "Blocs arrondis et colorés avec des entrées basées sur des icônes, similaire à Scratch.",
+        "GERAS": "Geras (Classique)",
+        "GERAS_DESCRIPTION": "L'apparence originale de Blockly, avec des blocs carrés et des entrées en ligne.",
+        "THRASOS": "Thrasos",
+        "THRASOS_DESCRIPTION": "Une version moderne de l'apparence classique de Blockly.",
+        "SELECTION": "Sélection du style des blocs",
+        "APPLY": "Appliquer le style",
+        "CHOOSE_DESCRIPTION": "Choisissez comment les blocs sont dessinés dans l'espace de travail. L'aperçu ci-dessous se met à jour selon votre choix."
     },
     "TOUR": {
         "MENU_ITEM": "Visite guidée",

--- a/frontend/i18n/locales/he.json
+++ b/frontend/i18n/locales/he.json
@@ -71,6 +71,7 @@
   "WPI_TOOLBOX": "ערכת כלים WPI",
   "SHOW_SIMPLE_CLASS_NAMES": "קיצור שמות כיתות על בלוקים",
   "THEME": "ערכת נושא",
+  "STYLE": "סגנון בלוקים",
   "LANGUAGE": "שפה",
   "SELECT_LANGUAGE": "בחר שפה",
   "ENGLISH": "אנגלית",
@@ -164,6 +165,17 @@
     "PRIMARY_BUTTON": "ראשי",
     "PREVIEW": "תצוגה מקדימה של ערכת נושא",
     "PREVIEW_DESCRIPTION": "ערכת הנושא הנבחרת תוחל על כל ממשק האפליקציה."
+  },
+  "RENDERER_MODAL": {
+    "ZELOS": "Zelos (בסגנון Scratch)",
+    "ZELOS_DESCRIPTION": "בלוקים מעוגלים וצבעוניים עם קלטים מבוססי סמלים, בדומה ל-Scratch.",
+    "GERAS": "Geras (קלאסי)",
+    "GERAS_DESCRIPTION": "המראה המקורי של Blockly, עם בלוקים מרובעים וקלטים בשורה.",
+    "THRASOS": "Thrasos",
+    "THRASOS_DESCRIPTION": "גרסה מודרנית של המראה הקלאסי של Blockly.",
+    "SELECTION": "בחירת סגנון בלוקים",
+    "APPLY": "החל סגנון",
+    "CHOOSE_DESCRIPTION": "בחר כיצד הבלוקים מצוירים באזור העבודה. התצוגה המקדימה למטה מתעדכנת בהתאם לבחירתך."
   },
   "TOUR": {
     "MENU_ITEM": "סיור",

--- a/frontend/modules/mechanism_start.json
+++ b/frontend/modules/mechanism_start.json
@@ -5,7 +5,7 @@
             {
                 "type": "mrc_class_method_def",
                 "x": 10,
-                "y": 150,
+                "y": 310,
                 "deletable": false,
                 "editable": false,
                 "extraState": {
@@ -23,7 +23,7 @@
             {
                 "type": "mrc_class_method_def",
                 "x": 10,
-                "y": 230,
+                "y": 510,
                 "editable": false,
                 "extraState": {
                     "canChangeSignature": false,

--- a/frontend/modules/opmode_start.json
+++ b/frontend/modules/opmode_start.json
@@ -18,7 +18,7 @@
             {
                 "type": "mrc_class_method_def",
                 "x": 10,
-                "y": 110,
+                "y": 310,
                 "deletable": false,
                 "editable": false,
                 "extraState": {
@@ -36,7 +36,7 @@
             {
                 "type": "mrc_class_method_def",
                 "x": 10,
-                "y": 190,
+                "y": 510,
                 "editable": false,
                 "extraState": {
                     "canChangeSignature": false,

--- a/frontend/modules/robot_start.json
+++ b/frontend/modules/robot_start.json
@@ -5,7 +5,7 @@
             {
                 "type": "mrc_class_method_def",
                 "x": 10,
-                "y": 150,
+                "y": 310,
                 "deletable": false,
                 "editable": false,
                 "extraState": {

--- a/frontend/reactComponents/BlocklyComponent.tsx
+++ b/frontend/reactComponents/BlocklyComponent.tsx
@@ -43,7 +43,10 @@ export interface BlocklyComponentProps {
   modulePath: string;
   onBlocklyComponentCreated: (modulePath: string, blocklyComponent: BlocklyComponentType) => void;
   theme: string;
+  renderer: string;
   onWorkspaceCreated: (modulePath: string, workspace: Blockly.WorkspaceSvg) => void;
+  /** When true, the workspace is display-only: no editing, scrolling, or zooming. */
+  readOnly?: boolean;
 }
 
 /** Grid spacing for the Blockly workspace. */
@@ -86,6 +89,7 @@ const WORKSPACE_STYLE: React.CSSProperties = {
 export default function BlocklyComponent(props: BlocklyComponentProps): React.JSX.Element {
   const blocklyDiv = React.useRef<HTMLDivElement | null>(null);
   const workspaceRef = React.useRef<Blockly.WorkspaceSvg | null>(null);
+  const currentRenderer = React.useRef<string>(props.renderer);
   const parentDiv = React.useRef<HTMLDivElement | null>(null);
   const savedScrollX = React.useRef<number>(0);
   const savedScrollY = React.useRef<number>(0);
@@ -121,22 +125,23 @@ export default function BlocklyComponent(props: BlocklyComponentProps): React.JS
       snap: true,
     },
     zoom: {
-      controls: true,
-      wheel: true,
+      controls: !props.readOnly,
+      wheel: !props.readOnly,
       startScale: DEFAULT_ZOOM_START_SCALE,
       maxScale: MAX_ZOOM_SCALE,
       minScale: MIN_ZOOM_SCALE,
       scaleSpeed: ZOOM_SCALE_SPEED,
     },
-    scrollbars: true,
+    scrollbars: !props.readOnly,
     trashcan: false,
     move: {
-      scrollbars: true,
-      drag: true,
-      wheel: true,
+      scrollbars: !props.readOnly,
+      drag: !props.readOnly,
+      wheel: !props.readOnly,
     },
     oneBasedIndex: false,
-    renderer: 'zelos',
+    renderer: props.renderer,
+    readOnly: props.readOnly,
     plugins: {
       ...HardwareConnectionsPluginInfo,
     },
@@ -213,6 +218,7 @@ export default function BlocklyComponent(props: BlocklyComponentProps): React.JS
     workspaceConfig.rtl = i18n.dir() === 'rtl';
     const workspace = Blockly.inject(blocklyDiv.current, workspaceConfig);
     workspaceRef.current = workspace;
+    currentRenderer.current = props.renderer;
     parentDiv.current = blocklyDiv.current.parentNode as HTMLDivElement;
   };
 
@@ -311,6 +317,18 @@ export default function BlocklyComponent(props: BlocklyComponentProps): React.JS
       workspaceRef.current.setTheme(newTheme);
     }
   }, [props.theme]);
+
+  // Blockly does not support switching renderers on an existing workspace, so the
+  // workspace must be recreated when the renderer changes.
+  React.useEffect(() => {
+    if (workspaceRef.current && currentRenderer.current !== props.renderer) {
+      cleanupWorkspace();
+      initializeWorkspace();
+      if (props.onWorkspaceCreated) {
+        props.onWorkspaceCreated(props.modulePath, workspaceRef.current!);
+      }
+    }
+  }, [props.renderer]);
 
   React.useEffect(() => {
     updateBlocklyLocale();

--- a/frontend/reactComponents/BlocklyComponent.tsx
+++ b/frontend/reactComponents/BlocklyComponent.tsx
@@ -56,7 +56,7 @@ const GRID_LENGTH = 3;
 const GRID_COLOR = '#ccc';
 
 /** Default zoom start scale. */
-const DEFAULT_ZOOM_START_SCALE = 1.0;
+const DEFAULT_ZOOM_START_SCALE = 0.6;
 
 /** Maximum zoom scale. */
 const MAX_ZOOM_SCALE = 3;
@@ -136,6 +136,7 @@ export default function BlocklyComponent(props: BlocklyComponentProps): React.JS
       wheel: true,
     },
     oneBasedIndex: false,
+    renderer: 'zelos',
     plugins: {
       ...HardwareConnectionsPluginInfo,
     },

--- a/frontend/reactComponents/Menu.tsx
+++ b/frontend/reactComponents/Menu.tsx
@@ -34,6 +34,7 @@ import {
   QuestionCircleOutlined,
   InfoCircleOutlined,
   BgColorsOutlined,
+  BuildOutlined,
   GlobalOutlined,
   CheckOutlined,
   ControlOutlined,
@@ -44,6 +45,7 @@ import ProjectManageModal from './ProjectManageModal';
 import AboutDialog from './AboutModal';
 import ThemeModal from './ThemeModal';
 import LanguageModal from './LanguageModal';
+import RendererModal from './RendererModal';
 
 /** Type definition for menu items. */
 type MenuItem = Required<Antd.MenuProps>['items'][number];
@@ -60,6 +62,8 @@ export interface MenuProps {
   openWPIToolboxSettings: () => void;
   theme: string;
   setTheme: (theme: string) => void;
+  renderer: string;
+  setRenderer: (renderer: string) => void;
   showSimpleClassNames: boolean;
   setShowSimpleClassNames: (show: boolean) => void;
   saveCurrentTab: () => Promise<void>;
@@ -140,6 +144,7 @@ function getMenuItems(
           showSimpleClassNames ? <CheckOutlined /> : undefined
         ),
       getItem(t('THEME') + '...', 'theme', <BgColorsOutlined />),
+      getItem(t('STYLE') + '...', 'renderer', <BuildOutlined />),
       getItem(t('LANGUAGE') + '...', 'language', <GlobalOutlined />),
     ]),
     getItem(t('HELP'), 'help', <QuestionCircleOutlined />, [
@@ -165,6 +170,7 @@ export function Component(props: MenuProps): React.JSX.Element {
   const [noProjects, setNoProjects] = React.useState<boolean>(false);
   const [aboutDialogVisible, setAboutDialogVisible] = React.useState<boolean>(false);
   const [themeModalOpen, setThemeModalOpen] = React.useState<boolean>(false);
+  const [rendererModalOpen, setRendererModalOpen] = React.useState<boolean>(false);
   const [languageModalOpen, setLanguageModalOpen] = React.useState<boolean>(false);
   const [deployModalOpen, setDeployModalOpen] = React.useState<boolean>(false);
   const [deployElapsed, setDeployElapsed] = React.useState<number>(0);
@@ -174,6 +180,10 @@ export function Component(props: MenuProps): React.JSX.Element {
 
   const handleThemeChange = (newTheme: string) => {
     props.setTheme(newTheme);
+  };
+
+  const handleRendererChange = (newRenderer: string) => {
+    props.setRenderer(newRenderer);
   };
 
   /** Fetches the list of project names from storage. */
@@ -279,6 +289,8 @@ export function Component(props: MenuProps): React.JSX.Element {
       props.setShowSimpleClassNames(!props.showSimpleClassNames)
     } else if (key === 'theme') {
       setThemeModalOpen(true);
+    } else if (key === 'renderer') {
+      setRendererModalOpen(true);
     } else if (key === 'language') {
       setLanguageModalOpen(true);
     } else if (key == 'deploy') {
@@ -436,6 +448,13 @@ export function Component(props: MenuProps): React.JSX.Element {
           onClose={() => setThemeModalOpen(false)}
           currentTheme={props.theme}
           onThemeChange={handleThemeChange}
+        />
+      <RendererModal
+          open={rendererModalOpen}
+          onClose={() => setRendererModalOpen(false)}
+          currentRenderer={props.renderer}
+          currentTheme={props.theme}
+          onRendererChange={handleRendererChange}
         />
       <LanguageModal
           open={languageModalOpen}

--- a/frontend/reactComponents/RendererModal.tsx
+++ b/frontend/reactComponents/RendererModal.tsx
@@ -1,0 +1,213 @@
+/**
+ * @license
+ * Copyright 2026 Porpoiseful LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Block style (renderer) selection modal component.
+ */
+
+import * as React from 'react';
+import * as Antd from 'antd';
+import * as Blockly from 'blockly/core';
+import * as I18Next from 'react-i18next';
+import { BuildOutlined } from '@ant-design/icons';
+
+import BlocklyComponent from './BlocklyComponent';
+
+interface RendererOption {
+    key: string;
+    name: string;
+    description: string;
+}
+
+export interface RendererModalProps {
+    open: boolean;
+    onClose: () => void;
+    currentRenderer: string;
+    currentTheme: string;
+    onRendererChange: (renderer: string) => void;
+}
+
+/** Module path used for the isolated preview workspace. It isn't a real module. */
+const PREVIEW_MODULE_PATH = '__renderer_preview__';
+
+/** A small sample block layout used to preview each renderer's visual style. */
+const PREVIEW_WORKSPACE_STATE = {
+    blocks: {
+        languageVersion: 0,
+        blocks: [
+            {
+                type: 'controls_if',
+                x: 20,
+                y: 20,
+                inputs: {
+                    IF0: {
+                        block: {
+                            type: 'logic_compare',
+                            fields: { OP: 'EQ' },
+                            inputs: {
+                                A: { block: { type: 'math_number', fields: { NUM: 1 } } },
+                                B: { block: { type: 'math_number', fields: { NUM: 1 } } },
+                            },
+                        },
+                    },
+                    DO0: {
+                        block: {
+                            type: 'text_print',
+                            inputs: {
+                                TEXT: { block: { type: 'text', fields: { TEXT: 'Hello' } } },
+                            },
+                        },
+                    },
+                },
+                next: {
+                    block: {
+                        type: 'controls_repeat_ext',
+                        inputs: {
+                            TIMES: { block: { type: 'math_number', fields: { NUM: 10 } } },
+                            DO: {
+                                block: {
+                                    type: 'text_print',
+                                    inputs: {
+                                        TEXT: { block: { type: 'text', fields: { TEXT: 'Hi' } } },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        ],
+    },
+};
+
+const RendererModal: React.FC<RendererModalProps> = ({
+    open,
+    onClose,
+    currentRenderer,
+    currentTheme,
+    onRendererChange,
+}) => {
+    const { t } = I18Next.useTranslation();
+    const [selectedRenderer, setSelectedRenderer] = React.useState(currentRenderer);
+
+    const RENDERER_OPTIONS: RendererOption[] = [
+        {
+            key: 'zelos',
+            name: t('RENDERER_MODAL.ZELOS'),
+            description: t('RENDERER_MODAL.ZELOS_DESCRIPTION'),
+        },
+        {
+            key: 'geras',
+            name: t('RENDERER_MODAL.GERAS'),
+            description: t('RENDERER_MODAL.GERAS_DESCRIPTION'),
+        },
+        {
+            key: 'thrasos',
+            name: t('RENDERER_MODAL.THRASOS'),
+            description: t('RENDERER_MODAL.THRASOS_DESCRIPTION'),
+        },
+    ];
+
+    React.useEffect(() => {
+        setSelectedRenderer(currentRenderer);
+    }, [currentRenderer, open]);
+
+    /** Loads the sample blocks into the preview workspace once it (re)initializes. */
+    const handlePreviewWorkspaceCreated = (_modulePath: string, workspace: Blockly.WorkspaceSvg): void => {
+        Blockly.serialization.workspaces.load(PREVIEW_WORKSPACE_STATE, workspace);
+    };
+
+    const handleApply = () => {
+        onRendererChange(selectedRenderer);
+        onClose();
+    };
+
+    const handleCancel = () => {
+        setSelectedRenderer(currentRenderer);
+        onClose();
+    };
+
+    return (
+        <Antd.Modal
+            title={
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                    <BuildOutlined />
+                    {t('RENDERER_MODAL.SELECTION')}
+                </div>
+            }
+            open={open}
+            onCancel={handleCancel}
+            footer={[
+                <Antd.Button key="cancel" onClick={handleCancel}>
+                    {t('CANCEL')}
+                </Antd.Button>,
+                <Antd.Button
+                    key="apply"
+                    type="primary"
+                    onClick={handleApply}
+                    disabled={selectedRenderer === currentRenderer}
+                >
+                    {t('RENDERER_MODAL.APPLY')}
+                </Antd.Button>,
+            ]}
+            width={600}
+            destroyOnHidden
+        >
+            <div style={{ padding: '16px 0' }}>
+                <Antd.Typography.Text type="secondary" style={{ marginBottom: 16, display: 'block' }}>
+                    {t('RENDERER_MODAL.CHOOSE_DESCRIPTION')}
+                </Antd.Typography.Text>
+
+                <Antd.Select
+                    value={selectedRenderer}
+                    onChange={(value) => setSelectedRenderer(value)}
+                    style={{ width: '100%' }}
+                    options={RENDERER_OPTIONS.map((renderer) => ({
+                        value: renderer.key,
+                        label: renderer.name,
+                    }))}
+                />
+
+                <Antd.Typography.Text type="secondary" style={{ fontSize: 12, display: 'block', marginTop: 8 }}>
+                    {RENDERER_OPTIONS.find((renderer) => renderer.key === selectedRenderer)?.description}
+                </Antd.Typography.Text>
+
+                <div
+                    style={{
+                        marginTop: 16,
+                        height: 300,
+                        border: '1px solid #d9d9d9',
+                        borderRadius: 4,
+                    }}
+                >
+                    {open && (
+                        <BlocklyComponent
+                            modulePath={PREVIEW_MODULE_PATH}
+                            theme={currentTheme}
+                            renderer={selectedRenderer}
+                            readOnly
+                            onBlocklyComponentCreated={() => {}}
+                            onWorkspaceCreated={handlePreviewWorkspaceCreated}
+                        />
+                    )}
+                </div>
+            </div>
+        </Antd.Modal>
+    );
+};
+
+export default RendererModal;

--- a/frontend/reactComponents/TabContent.tsx
+++ b/frontend/reactComponents/TabContent.tsx
@@ -52,6 +52,7 @@ export interface TabContentProps {
   project: storageProject.Project;
   storage: commonStorage.Storage;
   theme: string;
+  renderer: string;
   showSimpleClassNames: boolean;
   shownPythonToolboxCategories: Set<string>;
   messageApi: MessageInstance;
@@ -70,6 +71,7 @@ export const TabContent = React.forwardRef<TabContentRef, TabContentProps>(({
   project,
   storage,
   theme,
+  renderer,
   showSimpleClassNames,
   shownPythonToolboxCategories,
   messageApi,
@@ -257,6 +259,7 @@ export const TabContent = React.forwardRef<TabContentRef, TabContentProps>(({
           modulePath={modulePath}
           onBlocklyComponentCreated={setupBlocklyComponent}
           theme={theme}
+          renderer={renderer}
           onWorkspaceCreated={setupWorkspace}
         />
       </Content>

--- a/frontend/reactComponents/Tabs.tsx
+++ b/frontend/reactComponents/Tabs.tsx
@@ -65,6 +65,7 @@ export interface TabsProps {
   setAlertErrorMessage: (message: string) => void;
   storage: commonStorage.Storage | null;
   theme: string;
+  renderer: string;
   showSimpleClassNames: boolean;
   shownPythonToolboxCategories: Set<string>;
   messageApi: MessageInstance;
@@ -643,6 +644,7 @@ export const Component = React.forwardRef<TabsRef, TabsProps>((props, ref): Reac
                     project={props.project}
                     storage={props.storage}
                     theme={props.theme}
+                    renderer={props.renderer}
                     showSimpleClassNames={props.showSimpleClassNames}
                     shownPythonToolboxCategories={props.shownPythonToolboxCategories}
                     messageApi={props.messageApi}

--- a/frontend/reactComponents/UserSettingsProvider.tsx
+++ b/frontend/reactComponents/UserSettingsProvider.tsx
@@ -27,11 +27,13 @@ import { Storage } from '../storage/common_storage';
 const USER_LANGUAGE_KEY = 'userLanguage';
 const USER_THEME_KEY = 'userTheme';
 const USER_SHOW_SIMPLE_CLASS_NAMES_KEY = 'userShowSimpleClassNames';
+const USER_RENDERER_KEY = 'userRenderer';
 
 /** Default values for user settings. */
 const DEFAULT_LANGUAGE = 'en';
 const DEFAULT_THEME = 'dark';
 const DEFAULT_SHOW_SIMPLE_CLASS_NAMES = true;
+const DEFAULT_RENDERER = 'zelos';
 
 /** Helper function to generate project-specific storage key for open tabs. */
 const getUserOptionsKey = (projectName: string): string => `user_options_${projectName}`;
@@ -41,6 +43,7 @@ export interface UserSettings {
   language: string;
   theme: string;
   showSimpleClassNames: boolean;
+  renderer: string;
 }
 
 /** User settings context interface. */
@@ -49,6 +52,7 @@ export interface UserSettingsContextType {
   updateLanguage: (language: string) => Promise<void>;
   updateTheme: (theme: string) => Promise<void>;
   updateShowSimpleClassNames: (showSimpleClassNames: boolean) => Promise<void>;
+  updateRenderer: (renderer: string) => Promise<void>;
   updateOpenTabs: (projectName: string, tabPaths: string[]) => Promise<void>;
   getOpenTabs: (projectName: string) => Promise<string[]>;
   isLoading: boolean;
@@ -76,6 +80,7 @@ export const UserSettingsProvider: React.FC<UserSettingsProviderProps> = ({
     language: DEFAULT_LANGUAGE,
     theme: DEFAULT_THEME,
     showSimpleClassNames: DEFAULT_SHOW_SIMPLE_CLASS_NAMES,
+    renderer: DEFAULT_RENDERER,
   });
   const [isLoading, setIsLoading] = React.useState<boolean>(true);
   const [error, setError] = React.useState<string | null>(null);
@@ -87,16 +92,18 @@ export const UserSettingsProvider: React.FC<UserSettingsProviderProps> = ({
         setIsLoading(true);
         setError(null);
 
-        const [language, theme, showSimpleClassNames] = await Promise.all([
+        const [language, theme, showSimpleClassNames, renderer] = await Promise.all([
           validStorage.fetchEntry(USER_LANGUAGE_KEY, DEFAULT_LANGUAGE),
           validStorage.fetchEntry(USER_THEME_KEY, DEFAULT_THEME),
           validStorage.fetchEntry(USER_SHOW_SIMPLE_CLASS_NAMES_KEY, DEFAULT_SHOW_SIMPLE_CLASS_NAMES.toString()),
+          validStorage.fetchEntry(USER_RENDERER_KEY, DEFAULT_RENDERER),
         ]);
 
         setSettings({
           language,
           theme,
           showSimpleClassNames: showSimpleClassNames.toLowerCase() === "true",
+          renderer,
         });
       } catch (err) {
         setError(`Failed to load user settings: ${err}`);
@@ -142,6 +149,21 @@ export const UserSettingsProvider: React.FC<UserSettingsProviderProps> = ({
     } catch (err) {
       setError(`Failed to save theme setting: ${err}`);
       console.error('Error saving theme setting:', err);
+      throw err;
+    }
+  };
+
+  /** Update renderer setting. */
+  const updateRenderer = async (renderer: string): Promise<void> => {
+    try {
+      setError(null);
+      if (storage) {
+        await storage.saveEntry(USER_RENDERER_KEY, renderer);
+        setSettings(prev => ({ ...prev, renderer }));
+      }
+    } catch (err) {
+      setError(`Failed to save renderer setting: ${err}`);
+      console.error('Error saving renderer setting:', err);
       throw err;
     }
   };
@@ -206,6 +228,7 @@ export const UserSettingsProvider: React.FC<UserSettingsProviderProps> = ({
     updateLanguage,
     updateTheme,
     updateShowSimpleClassNames,
+    updateRenderer,
     updateOpenTabs,
     getOpenTabs,
     isLoading,


### PR DESCRIPTION
## Overview
This allows the user to change the renderer style.  The default is Zelos (Scratch like).   It does this through a new settings option.  The setting is stored along with the other user settings on the browser being used.

## Linked Issues
None, but related to feedback we are getting.  It seems that making it feel more like Scratch might make people happier.

## Type of Change
<!-- Please check the option that applies to this PR: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Code style/formatting updates
- [x] Display change

## How Has This Been Tested?
Making a new project, looking through the various categories.  Making a new module of each type and looking at the default.
I changed to all three options and verified that it looks correct.

## Checklist
<!-- Review the options below and check off what has been completed. -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [N/A] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [N/A] I have run through the [docs/testing_before_pr_checklist.md]
