### PR TITLE
Fix class name

### DIFF
--- a/frontend/i18n/locales/en.json
+++ b/frontend/i18n/locales/en.json
@@ -156,7 +156,7 @@
         "ERROR_LOADING_DEPENDENCIES": "Error loading dependencies.",
         "COPYRIGHT": "© 2025-2026 FIRST. All rights reserved."
     },
-    "INVALID_CLASS_NAME": "{{className}} is not a valid name. Please enter a different name.",
+    "INVALID_CLASS_NAME": "{{name}} is not a valid name. Please enter a different name.",
     "CLASS_NAME_ALREADY_EXISTS": "Another Mechanism or OpMode is already named {{name}}. Please enter a different name.",
     "PYTHON_MODULE_NAME_ALREADY_EXISTS": "{{name}} is not a valid name because there is a python module named {{moduleName}}.",
     "THEME_MODAL": {

--- a/frontend/i18n/locales/fr.json
+++ b/frontend/i18n/locales/fr.json
@@ -157,7 +157,7 @@
         "ERROR_LOADING_DEPENDENCIES": "Erreur lors du chargement des dépendances.",
         "COPYRIGHT": "© 2025-2026 FIRST. Tous droits réservés."
     },
-    "INVALID_CLASS_NAME": "{{className}} n'est pas un nom valide. Veuillez saisir un nom différent.",
+    "INVALID_CLASS_NAME": "{{name}} n'est pas un nom valide. Veuillez saisir un nom différent.",
     "CLASS_NAME_ALREADY_EXISTS": "Un autre mécanisme ou OpMode est déjà nommé {{name}}. Veuillez saisir un nom différent.",
     "PYTHON_MODULE_NAME_ALREADY_EXISTS": "{{name}} n'est pas un nom valide car il existe un module Python nommé {{moduleName}}.",
     "THEME_MODAL": {

--- a/frontend/storage/names.ts
+++ b/frontend/storage/names.ts
@@ -64,11 +64,11 @@ export const UPLOAD_DOWNLOAD_FILE_EXTENSION = '.blocks';
 // The file name of the project info file.
 const PROJECT_INFO_FILE_NAME = 'project.info.json';
 
-// A project name starts with an uppercase letter, followed by alphanumeric characters.
-const REGEX_PROJECT_NAME_PART = '[A-Z][A-Za-z0-9]*';
+// A project name starts with an uppercase letter, followed by alphanumeric characters or an underscore.
+const REGEX_PROJECT_NAME_PART = '[A-Z][A-Za-z0-9_]*';
 
-// A module's class name starts with an uppercase letter, followed by alphanumeric characters.
-const REGEX_CLASS_NAME_PART = '[A-Z][A-Za-z0-9]*';
+// A module's class name starts with an uppercase letter, followed by alphanumeric characters or an underscore.
+const REGEX_CLASS_NAME_PART = '[A-Z][A-Za-z0-9_]*';
 
 // This regex is used to validate a class name
 const REGEX_CLASS_NAME = '^' + REGEX_CLASS_NAME_PART + '$'


### PR DESCRIPTION
## Overview
Found this bug when demoing to FTC tech team.   We weren't allowing _ in class or project names.

## Linked Issues
Fixes #492

## Type of Change
<!-- Please check the option that applies to this PR: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Code style/formatting updates

## How Has This Been Tested?
Verified that it now allows _ in class and project names

## Checklist
<!-- Review the options below and check off what has been completed. -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [N/A] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [N/A] I have run through the [docs/testing_before_pr_checklist.md]
