### PR TITLE
Change storage location on systemcore to user directory so it will persist between OS updates

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -1,3 +1,17 @@
+import logging
 import os
+import shutil
 
-basedir = os.path.abspath(os.path.dirname(__file__))
+logger = logging.getLogger(__name__)
+
+DATA_DIR = os.path.expanduser('~/systemcore/blocks')
+DB_PATH = os.path.join(DATA_DIR, 'projects.db')
+
+os.makedirs(DATA_DIR, exist_ok=True)
+
+# Older versions of the backend stored the database alongside the code. If the
+# database hasn't already been migrated, move it to its new location.
+_OLD_DB_PATH = '/opt/blocks/backend/projects.db'
+if not os.path.exists(DB_PATH) and os.path.exists(_OLD_DB_PATH):
+    logger.info('Moving projects.db from %s to %s', _OLD_DB_PATH, DB_PATH)
+    shutil.move(_OLD_DB_PATH, DB_PATH)

--- a/backend/config.py
+++ b/backend/config.py
@@ -4,7 +4,7 @@ import shutil
 
 logger = logging.getLogger(__name__)
 
-DATA_DIR = os.path.expanduser('~/systemcore/blocks')
+DATA_DIR = os.path.expanduser('~systemcore/blocks')
 DB_PATH = os.path.join(DATA_DIR, 'projects.db')
 
 os.makedirs(DATA_DIR, exist_ok=True)

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,14 +1,13 @@
 # Standard library imports
 import argparse
 import logging
-import os
 from typing import Tuple, Union
 
 # Third-party imports
 from flask import Flask, jsonify, request, send_from_directory, Response
 
 # Our imports
-from config import basedir
+from config import DB_PATH
 from extensions import db
 from deploy import DeployResource
 from storage import StorageEntryResource, StorageFileRenameResource, StorageRootResource, StorageResource
@@ -38,7 +37,7 @@ def handle_preflight() -> Union[Response, None]:
         return response
 
 # Configure SQLite database
-app.config['SQLALCHEMY_DATABASE_URI'] = f'sqlite:///{os.path.join(basedir, "projects.db")}'
+app.config['SQLALCHEMY_DATABASE_URI'] = f'sqlite:///{DB_PATH}'
 db.init_app(app)
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "system_core_blocks",
-  "version": "0.2.0",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "system_core_blocks",
-      "version": "0.2.0",
+      "version": "0.2.2",
       "dependencies": {
         "@ant-design/icons": "^6.3.2",
         "@blockly/theme-dark": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "system_core_blocks",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "homepage": "/blocks",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
This bumps the version to 0.2.2 so we can make a release after it is merged.

## Overview
This changes the location for the backend database to be `~/systemcore/blocks`.  In addition, if there was already a backend db it moves it.

## Linked Issues
Fixes #505

## Type of Change
<!-- Please check the option that applies to this PR: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes ex isting functionality to change)
- [ ] Documentation update
- [ ] Code style/formatting updates

## How Has This Been Tested?
1. Uploaded to Systemcore with an existing db in the old location
2. Tested with a Systemcore with an existing db in the new location
3. Tested with a Systemcore with no existing db.

## Checklist
<!-- Review the options below and check off what has been completed. -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [N/A] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [N/A] I have run through the [docs/testing_before_pr_checklist.md]
