### PR TITLE
Change so the theme dialog looks like the blocks style dialog

### DIFF
--- a/frontend/reactComponents/Menu.tsx
+++ b/frontend/reactComponents/Menu.tsx
@@ -349,6 +349,7 @@ export function Component(props: MenuProps): React.JSX.Element {
           open={themeModalOpen}
           onClose={() => setThemeModalOpen(false)}
           currentTheme={props.theme}
+          currentRenderer={props.renderer}
           onThemeChange={handleThemeChange}
         />
       <RendererModal

--- a/frontend/reactComponents/ThemeModal.tsx
+++ b/frontend/reactComponents/ThemeModal.tsx
@@ -5,21 +5,14 @@
 import * as React from 'react';
 import * as Antd from 'antd';
 import * as I18Next from 'react-i18next';
-
-import {
-    BgColorsOutlined,
-    CheckOutlined,
-    MoonOutlined,
-    SunOutlined,
-} from '@ant-design/icons';
+import { BgColorsOutlined } from '@ant-design/icons';
 
 import ReadOnlyBlocklyPreview from './ReadOnlyBlocklyPreview';
 import { SAMPLE_PREVIEW_MODULE_CONTENT_TEXT } from './PreviewSampleContent';
 
-export interface ThemeOption {
+interface ThemeOption {
     key: string;
     name: string;
-    icon: React.ReactNode;
     description: string;
 }
 
@@ -27,6 +20,7 @@ export interface ThemeModalProps {
     open: boolean;
     onClose: () => void;
     currentTheme: string;
+    currentRenderer: string;
     onThemeChange: (themeKey: string) => void;
 }
 
@@ -34,6 +28,7 @@ const ThemeModal: React.FC<ThemeModalProps> = ({
     open,
     onClose,
     currentTheme,
+    currentRenderer,
     onThemeChange,
 }) => {
     const { t } = I18Next.useTranslation();
@@ -43,50 +38,40 @@ const ThemeModal: React.FC<ThemeModalProps> = ({
         {
             key: 'light',
             name: t('THEME_MODAL.LIGHT'),
-            icon: <SunOutlined />,
             description: t('THEME_MODAL.LIGHT_DESCRIPTION'),
         },
         {
             key: 'dark',
             name: t('THEME_MODAL.DARK'),
-            icon: <MoonOutlined />,
             description: t('THEME_MODAL.DARK_DESCRIPTION'),
         },
         {
             key: 'tritanopia',
             name: t('THEME_MODAL.TRITANOPIA'),
-            icon: <SunOutlined />,
             description: t('THEME_MODAL.TRITANOPIA_DESCRIPTION'),
         },
         {
             key: 'tritanopia-dark',
             name: t('THEME_MODAL.TRITANOPIA_DARK'),
-            icon: <MoonOutlined />,
             description: t('THEME_MODAL.TRITANOPIA_DARK_DESCRIPTION'),
         },
         {
             key: 'deuteranopia',
             name: t('THEME_MODAL.DEUTERANOPIA'),
-            icon: <SunOutlined />,
             description: t('THEME_MODAL.DEUTERANOPIA_DESCRIPTION'),
         },
         {
             key: 'deuteranopia-dark',
             name: t('THEME_MODAL.DEUTERANOPIA_DARK'),
-            icon: <MoonOutlined />,
             description: t('THEME_MODAL.DEUTERANOPIA_DARK_DESCRIPTION'),
         },
     ];
 
     React.useEffect(() => {
         setSelectedTheme(currentTheme);
-    }, [currentTheme]);
+    }, [currentTheme, open]);
 
-    const handleThemeSelect = (themeKey: string) => {
-        setSelectedTheme(themeKey);
-    };
-
-    const handleApplyTheme = () => {
+    const handleApply = () => {
         onThemeChange(selectedTheme);
         onClose();
     };
@@ -113,7 +98,7 @@ const ThemeModal: React.FC<ThemeModalProps> = ({
                 <Antd.Button
                     key="apply"
                     type="primary"
-                    onClick={handleApplyTheme}
+                    onClick={handleApply}
                     disabled={selectedTheme === currentTheme}
                 >
                     {t('THEME_MODAL.APPLY')}
@@ -127,88 +112,37 @@ const ThemeModal: React.FC<ThemeModalProps> = ({
                     {t('THEME_MODAL.CHOOSE_DESCRIPTION')}
                 </Antd.Typography.Text>
 
-                <Antd.Row gutter={[16, 16]}>
-                    {THEME_OPTIONS.map((theme) => (
-                        <Antd.Col span={12} key={theme.key}>
-                            <Antd.ConfigProvider theme={antdThemeFromString(theme.key)}>
-                                <Antd.Card
-                                    hoverable
-                                    className={`theme-option-card ${selectedTheme === theme.key ? 'selected' : ''}`}
-                                    onClick={() => handleThemeSelect(theme.key)}
-                                    style={{
-                                        border: selectedTheme === theme.key ? '2px solid #1890ff' : '1px solid #d9d9d9',
-                                        position: 'relative',
-                                        cursor: 'pointer',
-                                    }}
-                                >
-                                    {selectedTheme === theme.key && (
-                                        <div
-                                            style={{
-                                                position: 'absolute',
-                                                top: 8,
-                                                right: 8,
-                                                // background: '#1890ff',
-                                                borderRadius: '50%',
-                                                width: 20,
-                                                height: 20,
-                                                display: 'flex',
-                                                alignItems: 'center',
-                                                justifyContent: 'center',
-                                            }}
-                                        >
-                                            <CheckOutlined style={{ fontSize: 12 }} />
-                                        </div>
-                                    )}
-
-                                    <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 8 }}>
-                                        <div
-                                            style={{
-                                                fontSize: 24,
-                                                color: selectedTheme === theme.key ? '#1890ff' : undefined,
-                                            }}
-                                        >
-                                            {theme.icon}
-                                        </div>
-                                        <Antd.Typography.Title level={5} style={{ margin: 0 }}>
-                                            {theme.name}
-                                        </Antd.Typography.Title>
-                                    </div>
-
-                                    <Antd.Typography.Text type="secondary" style={{ fontSize: 12 }}>
-                                        {theme.description}
-                                    </Antd.Typography.Text>
-
-                                    {/* Theme preview */}
-                                    <div
-                                        style={{
-                                            marginTop: 12,
-                                            height: 140,
-                                            border: '1px solid #d9d9d9',
-                                            borderRadius: 4,
-                                        }}
-                                    >
-                                        <ReadOnlyBlocklyPreview
-                                            moduleContentText={SAMPLE_PREVIEW_MODULE_CONTENT_TEXT}
-                                            theme={theme.key}
-                                            interactive={false}
-                                        />
-                                    </div>
-                                </Antd.Card>
-                            </Antd.ConfigProvider>
-
-                        </Antd.Col>
-                    ))}
-                </Antd.Row>
-
-                <Antd.Divider />
-
-                <Antd.Alert
-                    title={t('THEME_MODAL.PREVIEW')}
-                    description={t('THEME_MODAL.PREVIEW_DESCRIPTION')}
-                    type="info"
-                    showIcon
-                    style={{ marginTop: 16 }}
+                <Antd.Select
+                    value={selectedTheme}
+                    onChange={(value) => setSelectedTheme(value)}
+                    style={{ width: '100%' }}
+                    options={THEME_OPTIONS.map((theme) => ({
+                        value: theme.key,
+                        label: theme.name,
+                    }))}
                 />
+
+                <Antd.Typography.Text type="secondary" style={{ fontSize: 12, display: 'block', marginTop: 8 }}>
+                    {THEME_OPTIONS.find((theme) => theme.key === selectedTheme)?.description}
+                </Antd.Typography.Text>
+
+                <div
+                    style={{
+                        marginTop: 16,
+                        height: 300,
+                        border: '1px solid #d9d9d9',
+                        borderRadius: 4,
+                    }}
+                >
+                    {open && (
+                        <ReadOnlyBlocklyPreview
+                            moduleContentText={SAMPLE_PREVIEW_MODULE_CONTENT_TEXT}
+                            theme={selectedTheme}
+                            renderer={currentRenderer}
+                            interactive={false}
+                        />
+                    )}
+                </div>
             </div>
         </Antd.Modal>
     );
@@ -237,8 +171,8 @@ export const antdThemeFromString = (theme: string): Antd.ThemeConfig => {
                     triggerBg: '#000000',
                 },
                 Menu: {
-                    darkItemBg: '#000000',  
-                    darkSubMenuItemBg: '#000000',                    
+                    darkItemBg: '#000000',
+                    darkSubMenuItemBg: '#000000',
                 }
             }
         }


### PR DESCRIPTION
## Overview
Makes the theme dialog look like the blocks style dialog.  (A dropdown that changes how it looks below instead of a small section of each one.)

## Linked Issues
None

## Type of Change
<!-- Please check the option that applies to this PR: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Code style/formatting updates
- [ ] Refactoring / Renaming
- [x] Other <!-- Make sure that it isn't one of the above -->

## How Has This Been Tested?
Bring up the dialog and try each theme

## Checklist
<!-- Review the options below and check off what has been completed. -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [N/A] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [N/A] I have run through the [docs/testing_before_pr_checklist.md]
